### PR TITLE
docs: sync direnv default version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This action provides environment variables via [direnv](https://direnv.net/),
 
 ## Inputs
 
-- `direnvVersion`: The version of direnv to use. Default: `2.32.1`
+- `direnvVersion`: The version of direnv to use. Default: `2.37.1`
 - `masks`: Comma seprated list of environment variables to mask. Default: `''`
 - `path`: The directory for direnv to use. Default: `.`
 
@@ -24,7 +24,7 @@ No outputs
 ```yaml
 uses: HatsuneMiku3939/direnv-action@v1
 with:
-  direnvVersion: 2.32.1
+  direnvVersion: 2.37.1
   masks: SECRET1, SECRET2
 ```
 


### PR DESCRIPTION
## Summary
- synchronize the documented default direnv version with the action metadata
- update the README usage example to match the current default value

## Background
The README documented `2.32.1` as the default `direnvVersion`, but `action.yml` uses `2.37.1`. This change removes that mismatch.

## Related issue(s)
- None

## Implementation details
- updated the `direnvVersion` default value in the README inputs section
- updated the example workflow snippet to use `2.37.1`

## Test coverage
- `npm run lint`
- `npm test`

## Breaking changes
- None

## Notes
- Documentation-only change

Created by Codex
