### PR TITLE
chore: align project metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,10 @@ No outputs
 
 ## Example usage
 
+Examples below pin the current release, `v1.1.2`. If you prefer the moving major tag, use `@v1`.
+
 ```yaml
-uses: HatsuneMiku3939/direnv-action@v1
+uses: HatsuneMiku3939/direnv-action@v1.1.2
 with:
   direnvVersion: 2.37.1
   masks: SECRET1, SECRET2
@@ -46,7 +48,7 @@ This loads the `.envrc` file from the repository root.
 To evaluate the `.envrc` in a subdirectory, set `path` explicitly:
 
 ```yaml
-uses: HatsuneMiku3939/direnv-action@v1
+uses: HatsuneMiku3939/direnv-action@v1.1.2
 with:
   path: child
   masks: SECRET1, SECRET2

--- a/action.yml
+++ b/action.yml
@@ -1,11 +1,11 @@
 name: 'direnv action'
-description: 'Privides environment variables via direnv'
+description: 'Provides environment variables via direnv'
 branding:
   icon: play
   color: green
 inputs:
   masks:
-    description: 'Comma seprated list of environment variables to mask'
+    description: 'Comma-separated list of environment variable names to mask'
     required: true
     default: ''
   direnvVersion:
@@ -13,7 +13,7 @@ inputs:
     required: true
     default: '2.37.1'
   path:
-    description: "directory for direnv to use"
+    description: 'Directory where direnv is evaluated'
     required: true
     default: .
 runs:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "javascript-action",
-  "version": "1.0.0",
+  "name": "direnv-action",
+  "version": "1.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "javascript-action",
-      "version": "1.0.0",
+      "name": "direnv-action",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "@actions/cache": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "javascript-action",
-  "version": "1.0.0",
-  "description": "JavaScript Action Template",
+  "name": "direnv-action",
+  "version": "1.1.2",
+  "description": "Provides environment variables via direnv",
   "type": "module",
   "main": "index.js",
   "scripts": {
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/actions/javascript-action.git"
+    "url": "git+https://github.com/HatsuneMiku3939/direnv-action.git"
   },
   "keywords": [
     "GitHub",
@@ -22,9 +22,9 @@
   "author": "",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/actions/javascript-action/issues"
+    "url": "https://github.com/HatsuneMiku3939/direnv-action/issues"
   },
-  "homepage": "https://github.com/actions/javascript-action#readme",
+  "homepage": "https://github.com/HatsuneMiku3939/direnv-action#readme",
   "dependencies": {
     "@actions/cache": "^6.0.0",
     "@actions/core": "^3.0.0",


### PR DESCRIPTION
## Summary

- Align the action description across action.yml, README.md, and package metadata.
- Update package metadata to match the HatsuneMiku3939/direnv-action repository.
- Pin README usage examples to the current release v1.1.2 while noting the moving major tag.

## Background

The repository still contained template metadata in package.json and inconsistent version and description text across project metadata files.

## Related issue(s)

- None.

## Implementation details

- Fix description and input text typos in action.yml.
- Update package.json and package-lock.json name, version, repository, bugs, and homepage fields.
- Update README examples and version references to match the current release metadata.

## Test coverage

- `npm run lint`
- `npm test`

## Breaking changes

- None.

## Notes

- No dedicated integration or e2e test suite exists in this repository today.

Created by Codex