### PR TITLE
Add project documentation: AGENTS.md and RELEASE_RUNBOOK.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+# Project Overview
+This repository contains a JavaScript-based GitHub Action that installs `direnv`, evaluates a target `.envrc`, and exports resulting environment variables (including special handling for `PATH`) to subsequent workflow steps while optionally masking selected values.
+
+## Project Map
+```text
+.
+├── action.yml                 # GitHub Action metadata, inputs, runtime entrypoint
+├── index.js                   # Action implementation and exported helpers
+├── index.test.js              # Jest unit tests with mocked @actions modules
+├── dist/                      # Bundled artifact consumed by GitHub Actions runtime
+├── package.json               # npm scripts and dependency definitions
+├── eslint.config.js           # ESLint flat config
+├── README.md                  # Usage, behavior, security, and development notes
+└── RELEASE_RUNBOOK.md         # Manual release process documentation
+```
+
+## Core Behaviors & Patterns
+- The action entrypoint (`main`) follows a fixed flow: install tool -> allow `.envrc` -> export JSON -> apply env vars -> mask secrets.
+- Binary resolution is explicit by `platform/arch` through `direnvBinaryURL`, with hard failures for unsupported targets.
+- Installation prefers GitHub tool-cache, then actions/cache restore, then direct download, and finally rehydrates both caches.
+- `PATH` from exported env is appended via `core.addPath`; all other keys are exported via `core.exportVariable`.
+- Tests are unit-focused and rely on `jest.unstable_mockModule` to isolate GitHub Actions SDK and command execution side effects.
+
+## Development Commands
+- Install dependencies: `npm ci`
+- Lint: `npm run lint`
+- Unit tests: `npm test`
+- Build distributable bundle: `npm run prepare`
+- Full local gate (lint + build + tests): `npm run all`
+
+## Coding Conventions
+- Tech stack: Node.js ESM modules, GitHub Actions toolkit packages, Jest, ESLint.
+- Keep functions small and composable; prefer pure helpers for branchable logic (e.g., URL/build decisions).
+- Preserve explicit error messages for unsupported platforms/architectures and propagate normalized failure text via `core.setFailed`.
+- Keep test cases table-driven where practical (`test.each`) and mock external side effects.
+- Generated `dist/` should be produced from source via `npm run prepare`; do not hand-edit bundled output.
+
+## Agent Guardrails
+- Always run `npm run lint` and `npm test` before proposing changes; run `npm run all` for release-affecting updates.
+- If source behavior changes, update tests in `index.test.js` and relevant documentation (`README.md`, runbooks) in the same change.
+- Keep `action.yml` entrypoint aligned with bundled output (`dist/index.js`) after build-related edits.
+- Do not introduce unsupported platform/arch mappings without matching implementation and tests.
+- > TODO: Confirm branch protection, PR label policy, and required CI checks from repository settings.

--- a/RELEASE_RUNBOOK.md
+++ b/RELEASE_RUNBOOK.md
@@ -1,0 +1,145 @@
+# Release Runbook
+
+This runbook documents the release flow for `latest` (from `master`) and `v1` (from the `v1` branch).
+
+## Scope
+
+- Keep `latest` aligned with the newest validated `master` state.
+- Keep `v1` aligned with `master` through a PR and CI gate.
+- Publish a new version tag from `v1`.
+
+## Prerequisites
+
+- You have push permission for `master`, `v1`, and tags.
+- `gh` CLI is authenticated (`gh auth status`).
+- Local repository is clean (`git status`).
+- Node dependencies are installed (`npm ci`).
+
+## Branch and Release Model
+
+1. `master` is the source of truth for the latest code and generated `dist` artifacts.
+2. `v1` is updated from `master` via pull request.
+3. Version tags are created from `v1` after synchronization.
+
+---
+
+## Phase 1: Update `master` and refresh `latest`
+
+1. Switch to `master` and update it:
+
+   ```bash
+   git checkout master
+   git pull --ff-only origin master
+   ```
+
+2. Run full validation and artifact generation:
+
+   ```bash
+   npm ci
+   npm run all
+   ```
+
+3. Commit generated changes (typically `dist/`) if needed:
+
+   ```bash
+   git add dist
+   git commit -m "chore(release): refresh dist artifacts"
+   ```
+
+4. Push to `master`:
+
+   ```bash
+   git push origin master
+   ```
+
+Expected result:
+- `latest` release reflects this updated `master` state.
+
+---
+
+## Phase 2: Sync `v1` from `master` through PR
+
+1. Create a sync branch from `v1`:
+
+   ```bash
+   git checkout v1
+   git pull --ff-only origin v1
+   git checkout -b chore/sync-master-into-v1-<date>
+   ```
+
+2. Merge `master` into the sync branch:
+
+   ```bash
+   git merge --no-ff origin/master
+   ```
+
+3. Push the sync branch:
+
+   ```bash
+   git push -u origin chore/sync-master-into-v1-<date>
+   ```
+
+4. Create a PR to `v1` with GitHub CLI:
+
+   ```bash
+   gh pr create \
+     --base v1 \
+     --head chore/sync-master-into-v1-<date> \
+     --title "Sync master into v1" \
+     --body "Sync master changes into v1 after latest refresh." \
+     --label documentation
+   ```
+
+5. Wait for CI to pass, then merge with merge commit:
+
+   ```bash
+   gh pr merge --merge
+   ```
+
+Expected result:
+- `v1` branch is synchronized with the latest `master` changes.
+
+---
+
+## Phase 3: Tag from `v1` and publish release
+
+1. Update local `v1` after merge:
+
+   ```bash
+   git checkout v1
+   git pull --ff-only origin v1
+   ```
+
+2. Choose the next semantic version (for example from `v1.1.2` to `v1.1.3`).
+3. Create an annotated tag on `v1` HEAD:
+
+   ```bash
+   git tag -a v1.1.3 -m "Release v1.1.3"
+   ```
+
+4. Push the tag:
+
+   ```bash
+   git push origin v1.1.3
+   ```
+
+Expected result:
+- Release workflow is triggered and published from the new `v1.x.y` tag.
+
+---
+
+## Operational Checklist
+
+- [ ] `master` updated with `npm run all` success.
+- [ ] Generated `dist` committed and pushed to `master`.
+- [ ] PR from sync branch into `v1` created.
+- [ ] CI passed on the PR.
+- [ ] PR merged using merge commit.
+- [ ] New version tag created from `v1`.
+- [ ] Tag pushed to remote.
+
+## Safety Notes
+
+- Do not tag from `master` if your policy requires tagging from `v1`.
+- Do not skip `npm run all`; otherwise, release artifacts may be inconsistent.
+- Confirm branch before tag creation (`git branch --show-current`).


### PR DESCRIPTION
### Motivation
- Provide a consolidated project overview, development conventions, and agent guardrails to guide contributors and automated agents.
- Document a repeatable, auditable release process for synchronizing `master` and `v1` and publishing versioned tags.

### Description
- Add `AGENTS.md` containing project map, core behaviors, development commands (`npm ci`, `npm run lint`, `npm test`, `npm run prepare`, `npm run all`), coding conventions, and agent guardrails.
- Add `RELEASE_RUNBOOK.md` describing a three-phase release flow with explicit commands for updating `master`, syncing `v1`, tagging from `v1`, and an operational checklist and safety notes.

### Testing
- No automated tests were run for this documentation-only change; repository CI is expected to run existing checks such as `npm run lint` and `npm test` when the PR is opened.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d070e016688320a32b72c6704f44e4)