### PR TITLE
docs: add repo-specific release skill

### DIFF
--- a/.agents/skills/direnv-action-release/SKILL.md
+++ b/.agents/skills/direnv-action-release/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: direnv-action-release
+description: Prepare and publish a release for the direnv-action repository when the user asks for a patch, minor, or major release, wants the RELEASE_RUNBOOK followed, or needs the version tag, GitHub Release, and moving v1 tag updated together.
+---
+
+# direnv-action Release
+
+Use this skill when the user asks to release `direnv-action`, bump the release version, or publish a new `v1.x.y` tag.
+
+## Required Context
+
+- Read `AGENTS.md` for repository guardrails and validation rules.
+- Read `RELEASE_RUNBOOK.md` for the canonical release flow.
+- Read [`references/release-flow.md`](./references/release-flow.md) for the command checklist.
+- Read [`references/release-guardrails.md`](./references/release-guardrails.md) before pushing or retagging.
+
+## Workflow
+
+1. Confirm the working tree is clean and `master` is up to date.
+2. Determine the next version from the requested release type and the latest `v*` tag.
+3. Update the version with `npm version <version> --no-git-tag-version`.
+4. Update release-facing documentation that pins an exact version tag.
+5. Run the full validation gate with `nvm use`, `npm ci`, and `npm run all`.
+6. Commit the release-preparation changes to `master` with a Conventional Commit message.
+7. Push `master`, create the annotated version tag, and publish the GitHub Release.
+8. Force-move the `v1` tag to the same commit and verify both tags resolve to the release commit.
+
+## Output Expectations
+
+Report:
+
+- the chosen release version
+- validation commands that passed
+- the release-preparation commit SHA
+- the version tag and GitHub Release URL
+- whether `v1` now points to the same commit

--- a/.agents/skills/direnv-action-release/references/release-flow.md
+++ b/.agents/skills/direnv-action-release/references/release-flow.md
@@ -1,0 +1,35 @@
+# Release Flow
+
+Use this checklist after reading `RELEASE_RUNBOOK.md`.
+
+1. Sync local state:
+   - `git checkout master`
+   - `git fetch --all --tags`
+   - `git pull --ff-only origin master`
+2. Validate the current tree:
+   - `nvm use`
+   - `npm ci`
+   - `npm run all`
+3. Inspect version state:
+   - `git tag --sort=-version:refname | head -n 5`
+   - `grep '"version":' package.json`
+   - `git log <last-release-tag>..HEAD --oneline`
+4. Apply the next version:
+   - `npm version <next-version> --no-git-tag-version`
+5. Update docs that pin the release tag, then rerun:
+   - `npm run all`
+6. Commit and publish:
+   - `git add package.json package-lock.json README.md dist`
+   - `git commit -m "chore(release): prepare <next-version-tag>"`
+   - `git push origin master`
+7. Tag and release:
+   - `git tag -a <next-version-tag> -m "Release <next-version-tag>"`
+   - `git push origin <next-version-tag>`
+   - `gh release create <next-version-tag> --title "<next-version-tag>" --generate-notes`
+8. Move the major tag:
+   - `git tag -fa v1 -m "Update v1 to <next-version-tag>"`
+   - `git push origin refs/tags/v1 --force`
+9. Verify:
+   - `git rev-list -n 1 <next-version-tag>`
+   - `git rev-list -n 1 v1`
+   - `gh release view <next-version-tag>`

--- a/.agents/skills/direnv-action-release/references/release-guardrails.md
+++ b/.agents/skills/direnv-action-release/references/release-guardrails.md
@@ -1,0 +1,11 @@
+# Release Guardrails
+
+- `master` is the release source of truth. Do not create the release from an outdated branch.
+- Use the Node version from `.nvmrc`.
+- Always run `npm run all` after the version bump.
+- Do not hand-edit `dist/`; regenerate it through `npm run prepare` as part of `npm run all`.
+- Update `README.md` when it pins the latest exact release tag.
+- Use a Conventional Commit message for the release-preparation commit.
+- Publish both the immutable version tag and the moving `v1` tag.
+- Verify `v1` and the version tag resolve to the same commit before finishing.
+- If pushing to `master` shows a branch-rule warning but the push succeeds, report that explicitly.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,9 @@ This repository contains a JavaScript-based GitHub Action that installs `direnv`
 ## Project Map
 ```text
 .
+├── .agents/skills/direnv-action-release/
+│   ├── SKILL.md              # Repo-specific release workflow for version/tag publishing
+│   └── references/           # Short release checklist and guardrails
 ├── action.yml                 # GitHub Action metadata, inputs, runtime entrypoint
 ├── index.js                   # Action implementation and exported helpers
 ├── index.test.js              # Jest unit tests with mocked @actions modules
@@ -40,6 +43,7 @@ This repository contains a JavaScript-based GitHub Action that installs `direnv`
 - Always run `npm run lint` and `npm test` before proposing changes; run `npm run all` for release-affecting updates.
 - If source behavior changes, update tests in `index.test.js` and relevant documentation (`README.md`, runbooks) in the same change.
 - Keep `action.yml` entrypoint aligned with bundled output (`dist/index.js`) after build-related edits.
+- For release work, prefer the repo skill at `.agents/skills/direnv-action-release/` and keep its references aligned with `RELEASE_RUNBOOK.md`.
 - Do not introduce unsupported platform/arch mappings without matching implementation and tests.
 - > TODO: Confirm branch protection, PR label policy, and required CI checks from repository settings.
 - You can push directly to `master` while in release process, but ensure all tests pass and the release runbook is followed for version bumps and changelog updates. For non-release changes, use feature branches and PRs with appropriate reviews.


### PR DESCRIPTION
## Summary

- add a repository-specific `direnv-action-release` skill under `.agents/skills/`
- split the release workflow into short reference files for command flow and guardrails
- document the new repo skill in `AGENTS.md`

## Background

The repository already has a `RELEASE_RUNBOOK.md` with a repeatable release process. Converting that process into a repo-specific skill reduces release drift and keeps the `v1` retagging and verification steps easy to follow.

## Related issue(s)

- None.

## Implementation details

- added `SKILL.md` with trigger conditions, required context, workflow, and output expectations
- added `references/release-flow.md` for the exact release checklist
- added `references/release-guardrails.md` for repo-specific safety rules
- updated `AGENTS.md` to point release work at the new skill

## Test coverage

- `npm run lint`
- `npm test`

## Breaking changes

- None.

## Notes

- the skill is repo-local and is intended to stay aligned with `RELEASE_RUNBOOK.md`

Created by Codex