### PR TITLE
[codex] chore(deps): group dev dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,17 @@ updates:
     # Check the npm registry for updates every day (weekdays)
     schedule:
       interval: "daily"
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+    cooldown:
+      default-days: 7
+      include:
+        - "@eslint/js"
+        - "@vercel/ncc"
+        - "eslint"
+        - "globals"
+        - "jest"
 
   # Enable version updates for actions
   - package-ecosystem: github-actions


### PR DESCRIPTION
## Summary

- Group npm development dependency version updates into a single Dependabot PR.
- Add a seven-day cooldown for the current npm development dependencies while keeping the npm schedule daily.

## Background

Dependabot currently checks npm updates daily. Development dependencies such as ESLint, Jest, and globals can create frequent separate PRs. The exact split of weekly development updates and daily production updates cannot be represented as separate overlapping npm update entries for the same directory, so this change uses grouping plus cooldown as the closest valid configuration.

## Related issue(s)

None.

## Implementation details

- Added a `dev-dependencies` Dependabot group using `dependency-type: "development"`.
- Added a seven-day cooldown for the current development dependencies: `@eslint/js`, `@vercel/ncc`, `eslint`, `globals`, and `jest`.
- Left the npm update schedule as `daily` so production dependencies are still checked daily.
- Left GitHub Actions updates on the existing weekly schedule.

## Test coverage

- `npx --yes js-yaml .github/dependabot.yml >/dev/null`
- `npm run all`

## Breaking changes

None.

## Notes

Created by Codex