### PR TITLE
docs: update release skill Pages guidance

### DIFF
--- a/.agents/skills/direnv-action-release/SKILL.md
+++ b/.agents/skills/direnv-action-release/SKILL.md
@@ -19,7 +19,7 @@ Use this skill when the user asks to release `direnv-action`, bump the release v
 1. Confirm the working tree is clean and `master` is up to date.
 2. Determine the next version from the requested release type and the latest `v*` tag.
 3. Update the version with `npm version <version> --no-git-tag-version`.
-4. Update release-facing documentation that pins an exact version tag.
+4. Update release-facing documentation that pins an exact version tag, including both `README.md` and `docs/index.html`.
 5. Run the full validation gate with `nvm use`, `npm ci`, and `npm run all`.
 6. Commit the release-preparation changes to `master` with a Conventional Commit message.
 7. Push `master`, create the annotated version tag, and publish the GitHub Release.

--- a/.agents/skills/direnv-action-release/references/release-flow.md
+++ b/.agents/skills/direnv-action-release/references/release-flow.md
@@ -16,10 +16,10 @@ Use this checklist after reading `RELEASE_RUNBOOK.md`.
    - `git log <last-release-tag>..HEAD --oneline`
 4. Apply the next version:
    - `npm version <next-version> --no-git-tag-version`
-5. Update docs that pin the release tag, then rerun:
+5. Update docs that pin the release tag, including `README.md` and `docs/index.html`, then rerun:
    - `npm run all`
 6. Commit and publish:
-   - `git add package.json package-lock.json README.md dist`
+   - `git add package.json package-lock.json README.md docs/index.html dist`
    - `git commit -m "chore(release): prepare <next-version-tag>"`
    - `git push origin master`
 7. Tag and release:

--- a/.agents/skills/direnv-action-release/references/release-guardrails.md
+++ b/.agents/skills/direnv-action-release/references/release-guardrails.md
@@ -4,7 +4,7 @@
 - Use the Node version from `.nvmrc`.
 - Always run `npm run all` after the version bump.
 - Do not hand-edit `dist/`; regenerate it through `npm run prepare` as part of `npm run all`.
-- Update `README.md` when it pins the latest exact release tag.
+- Update both `README.md` and `docs/index.html` when they pin the latest exact release tag.
 - Use a Conventional Commit message for the release-preparation commit.
 - Publish both the immutable version tag and the moving `v1` tag.
 - Verify `v1` and the version tag resolve to the same commit before finishing.

--- a/RELEASE_RUNBOOK.md
+++ b/RELEASE_RUNBOOK.md
@@ -100,11 +100,12 @@ Expected result:
 
    Example:
    - Update `README.md` examples from the previous version tag to `<next-version-tag>` when the pinned release snippets change.
+   - Update `docs/index.html` examples from the previous version tag to `<next-version-tag>` when the Pages documentation pins the release tag.
 
 9. Commit generated changes (typically `package.json`, `package-lock.json`, `dist/`, and any release-related documentation updates) if needed:
 
    ```bash
-   git add package.json package-lock.json dist README.md
+   git add package.json package-lock.json dist README.md docs/index.html
    git commit -m "chore(release): prepare <next-version-tag>"
    ```
 
@@ -178,7 +179,7 @@ Expected result:
 
 - [ ] `master` updated with `npm run all` success.
 - [ ] Release version determined and applied if needed.
-- [ ] Documentation updated for the latest pinned release version where applicable.
+- [ ] `README.md` and `docs/index.html` updated for the latest pinned release version where applicable.
 - [ ] Generated `dist` and version files committed and pushed to `master`.
 - [ ] New version tag created from `master`.
 - [ ] Version tag pushed to remote.
@@ -189,6 +190,7 @@ Expected result:
 
 - Do not create the release tag from an outdated local checkout.
 - Do not skip the second `npm run all` after `npm version`; the generated artifacts and lockfile must match the release version.
+- Do not update only one release-facing document when both `README.md` and `docs/index.html` pin the latest exact release tag.
 - Do not recreate the old `v1` branch after migration; `v1` should remain a tag only.
 - Force-updating `v1` changes what `@v1` resolves to, so confirm the target commit before pushing.
 - If the repository enables immutable release or tag policies, verify that moving `v1` is still allowed before starting the release.


### PR DESCRIPTION
## Summary

- Update the `direnv-action-release` skill to require updating `docs/index.html` alongside `README.md` when release tags change.
- Keep the bundled release-flow and release-guardrails references aligned with that rule.
- Update `RELEASE_RUNBOOK.md` with the same Pages documentation requirement.

## Background

The repository now publishes a GitHub Pages documentation site from `docs/index.html`, and that page pins exact release tags just like the README. Release preparation instructions should update both documents together.

## Related issue(s)

None.

## Implementation details

- Added `docs/index.html` to the release-facing documentation update step in `SKILL.md`.
- Updated the release checklist staging command to include `docs/index.html`.
- Added runbook examples and a safety note to avoid updating only one pinned release document.

## Test coverage

- `python3 /home/filepang/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/direnv-action-release`
- `npm run all`
- `npm audit`
- `git diff --check`

## Breaking changes

None.

## Notes

Created by Codex
