### PR TITLE
docs: redesign GitHub Pages documentation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,22 +4,26 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>direnv-action documentation</title>
-  <meta name="description" content="Usage documentation for the direnv-action GitHub Action.">
+  <meta name="description" content="Reference documentation for using direnv-action in GitHub Actions workflows.">
+  <link rel="canonical" href="https://hatsunemiku3939.github.io/direnv-action/">
   <style>
     :root {
       color-scheme: light;
-      --bg: #f7f9fb;
-      --panel: #ffffff;
-      --text: #17202a;
-      --muted: #5d6978;
-      --line: #d8e0ea;
-      --accent: #18745b;
-      --accent-strong: #105a46;
-      --code-bg: #101820;
-      --code-text: #e7edf3;
-      --warn-bg: #fff7df;
-      --warn-line: #e0b84f;
-      --shadow: 0 12px 30px rgb(23 32 42 / 8%);
+      --paper: #f5f1e7;
+      --paper-deep: #ebe3d3;
+      --ink: #171512;
+      --ink-soft: #514b43;
+      --ink-faint: #81786a;
+      --rule: #cfc4af;
+      --rule-dark: #8d806b;
+      --green: #006f55;
+      --green-soft: #d9eadf;
+      --amber: #9c6a00;
+      --red: #a13b2d;
+      --blue: #245f87;
+      --code: #171512;
+      --code-paper: #fffaf0;
+      --focus: #0f67a9;
     }
 
     * {
@@ -32,249 +36,325 @@
 
     body {
       margin: 0;
-      background: var(--bg);
-      color: var(--text);
-      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-      line-height: 1.6;
+      background:
+        linear-gradient(90deg, rgb(23 21 18 / 4%) 1px, transparent 1px) 0 0 / 72px 72px,
+        linear-gradient(0deg, rgb(23 21 18 / 3%) 1px, transparent 1px) 0 0 / 72px 72px,
+        var(--paper);
+      color: var(--ink);
+      font-family: "Azeret Mono", "IBM Plex Mono", "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
+      line-height: 1.55;
     }
 
     a {
-      color: var(--accent-strong);
-      text-decoration-thickness: 2px;
+      color: var(--blue);
+      text-decoration: underline;
+      text-decoration-thickness: 1px;
       text-underline-offset: 3px;
     }
 
-    header {
-      background: var(--panel);
-      border-bottom: 1px solid var(--line);
+    a:focus-visible,
+    button:focus-visible {
+      outline: 3px solid var(--focus);
+      outline-offset: 3px;
     }
 
-    .wrap {
-      width: min(1120px, calc(100% - 32px));
+    .page {
+      width: min(1180px, calc(100% - 32px));
       margin: 0 auto;
     }
 
-    .topbar {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 20px;
-      padding: 18px 0;
+    .masthead {
+      padding: 28px 0 22px;
+      border-bottom: 2px solid var(--ink);
     }
 
-    .brand {
-      display: flex;
-      align-items: center;
-      gap: 12px;
-      font-weight: 700;
-    }
-
-    .mark {
+    .masthead-line {
       display: grid;
-      place-items: center;
-      width: 38px;
-      height: 38px;
-      border-radius: 8px;
-      background: var(--accent);
-      color: white;
-      font-family: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace;
-      font-size: 18px;
+      grid-template-columns: 1fr auto;
+      gap: 18px;
+      align-items: start;
     }
 
-    nav {
+    .manual-id {
       display: flex;
       flex-wrap: wrap;
-      justify-content: flex-end;
-      gap: 12px;
-      font-size: 14px;
+      gap: 8px;
+      margin-bottom: 26px;
+      color: var(--ink-soft);
+      font-size: 13px;
+      text-transform: uppercase;
     }
 
-    nav a {
-      color: var(--muted);
-      text-decoration: none;
-    }
-
-    nav a:hover {
-      color: var(--accent-strong);
-    }
-
-    .hero {
-      display: grid;
-      grid-template-columns: minmax(0, 1.15fr) minmax(300px, 0.85fr);
-      gap: 36px;
-      align-items: center;
-      padding: 56px 0 44px;
+    .manual-id span {
+      padding: 3px 7px;
+      border: 1px solid var(--rule-dark);
+      background: var(--paper-deep);
     }
 
     h1 {
+      max-width: 920px;
       margin: 0;
-      font-size: clamp(40px, 7vw, 72px);
-      line-height: 0.95;
+      font-size: clamp(42px, 9vw, 112px);
+      line-height: 0.88;
       letter-spacing: 0;
+      text-transform: uppercase;
     }
 
-    .lead {
-      max-width: 720px;
-      margin: 20px 0 0;
-      color: var(--muted);
-      font-size: 18px;
+    .tagline {
+      max-width: 760px;
+      margin: 18px 0 0;
+      color: var(--ink-soft);
+      font-size: 16px;
     }
 
-    .actions {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 12px;
-      margin-top: 26px;
-    }
-
-    .button {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      min-height: 42px;
-      padding: 0 16px;
-      border: 1px solid var(--accent);
-      border-radius: 8px;
-      background: var(--accent);
-      color: #fff;
-      font-weight: 700;
+    .repo-link {
+      display: inline-block;
+      min-width: 170px;
+      padding: 9px 10px;
+      border: 2px solid var(--ink);
+      color: var(--ink);
+      text-align: center;
       text-decoration: none;
+      text-transform: uppercase;
+      box-shadow: 5px 5px 0 var(--ink);
+      transition: transform 120ms ease, box-shadow 120ms ease;
     }
 
-    .button.secondary {
-      background: transparent;
-      color: var(--accent-strong);
+    .repo-link:hover {
+      transform: translate(2px, 2px);
+      box-shadow: 3px 3px 0 var(--ink);
     }
 
-    .flow {
+    .terminal-strip {
       display: grid;
-      gap: 10px;
-      padding: 18px;
-      border: 1px solid var(--line);
-      border-radius: 8px;
-      background: var(--panel);
-      box-shadow: var(--shadow);
+      grid-template-columns: 1.05fr 0.95fr;
+      gap: 18px;
+      margin: 24px 0 0;
     }
 
-    .flow-step {
-      display: grid;
-      grid-template-columns: 34px 1fr;
+    .trace {
+      border: 2px solid var(--ink);
+      background: var(--code);
+      color: #f7f1e6;
+    }
+
+    .trace-head {
+      display: flex;
+      justify-content: space-between;
       gap: 12px;
-      align-items: center;
-      padding: 12px;
-      border: 1px solid var(--line);
-      border-radius: 8px;
-      background: #fbfdff;
+      padding: 10px 12px;
+      border-bottom: 1px solid #5f584d;
+      color: #d6ccb8;
+      font-size: 12px;
+      text-transform: uppercase;
     }
 
-    .flow-step span {
+    .trace pre {
+      margin: 0;
+      padding: 16px;
+      overflow-x: auto;
+      color: inherit;
+      font-size: 13px;
+      line-height: 1.7;
+    }
+
+    .trace .ok {
+      color: #8be0b4;
+    }
+
+    .trace .warn {
+      color: #f3cd79;
+    }
+
+    .quick-facts {
       display: grid;
-      place-items: center;
-      width: 34px;
-      height: 34px;
-      border-radius: 8px;
-      background: #e2f4ee;
-      color: var(--accent-strong);
-      font-weight: 800;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      border: 2px solid var(--ink);
+      background: var(--code-paper);
+    }
+
+    .fact {
+      min-height: 112px;
+      padding: 14px;
+      border-right: 1px solid var(--rule);
+      border-bottom: 1px solid var(--rule);
+    }
+
+    .fact:nth-child(2n) {
+      border-right: 0;
+    }
+
+    .fact:nth-last-child(-n + 2) {
+      border-bottom: 0;
+    }
+
+    .fact strong {
+      display: block;
+      margin-bottom: 8px;
+      font-size: 12px;
+      text-transform: uppercase;
+      color: var(--ink-faint);
+    }
+
+    .layout {
+      display: grid;
+      grid-template-columns: 230px minmax(0, 1fr);
+      gap: 34px;
+      padding: 34px 0 72px;
+    }
+
+    nav {
+      position: sticky;
+      top: 16px;
+      align-self: start;
+      padding: 16px 0 0;
+      border-top: 2px solid var(--ink);
+    }
+
+    nav a {
+      display: block;
+      padding: 9px 0;
+      border-bottom: 1px solid var(--rule);
+      color: var(--ink-soft);
+      text-decoration: none;
+      text-transform: uppercase;
+      font-size: 13px;
+    }
+
+    nav a:hover {
+      color: var(--ink);
     }
 
     main {
-      padding: 28px 0 72px;
+      display: grid;
+      gap: 28px;
     }
 
     section {
-      scroll-margin-top: 20px;
-      margin-top: 36px;
-      padding: 30px;
-      border: 1px solid var(--line);
-      border-radius: 8px;
-      background: var(--panel);
-      box-shadow: var(--shadow);
+      scroll-margin-top: 18px;
+      padding: 28px;
+      border: 2px solid var(--ink);
+      background: rgb(255 250 240 / 82%);
+    }
+
+    .section-kicker {
+      display: inline-block;
+      margin-bottom: 18px;
+      color: var(--green);
+      font-size: 12px;
+      text-transform: uppercase;
     }
 
     h2 {
-      margin: 0 0 16px;
-      font-size: 28px;
-      line-height: 1.15;
+      margin: 0 0 18px;
+      font-size: clamp(26px, 5vw, 54px);
+      line-height: 0.95;
       letter-spacing: 0;
+      text-transform: uppercase;
     }
 
     h3 {
-      margin: 24px 0 10px;
-      font-size: 18px;
+      margin: 24px 0 8px;
+      font-size: 17px;
       letter-spacing: 0;
+      text-transform: uppercase;
     }
 
     p {
+      max-width: 78ch;
       margin: 0 0 14px;
     }
 
-    .grid {
-      display: grid;
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-      gap: 16px;
+    code {
+      font-family: inherit;
+      font-size: 0.95em;
     }
 
-    .note,
-    .input-card {
+    .code-block {
+      margin: 16px 0 0;
+      border: 1px solid var(--ink);
+      background: var(--code);
+      color: #f7f1e6;
+    }
+
+    .code-label {
+      padding: 8px 10px;
+      border-bottom: 1px solid #5f584d;
+      color: #d6ccb8;
+      font-size: 12px;
+      text-transform: uppercase;
+    }
+
+    pre {
+      margin: 0;
       padding: 16px;
-      border: 1px solid var(--line);
-      border-radius: 8px;
-      background: #fbfdff;
-    }
-
-    .note.warning {
-      border-color: var(--warn-line);
-      background: var(--warn-bg);
-    }
-
-    .input-card strong {
-      display: block;
-      margin-bottom: 6px;
-      font-family: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace;
+      overflow-x: auto;
+      line-height: 1.65;
+      font-size: 13px;
     }
 
     table {
       width: 100%;
       border-collapse: collapse;
-      margin-top: 12px;
-      overflow-wrap: anywhere;
+      margin: 16px 0 0;
+      background: var(--code-paper);
     }
 
     th,
     td {
       padding: 12px;
-      border: 1px solid var(--line);
+      border: 1px solid var(--rule-dark);
       text-align: left;
       vertical-align: top;
     }
 
     th {
-      background: #eef4f8;
-      font-size: 14px;
+      background: var(--paper-deep);
+      color: var(--ink-soft);
+      font-size: 12px;
+      text-transform: uppercase;
     }
 
-    code {
-      font-family: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace;
-      font-size: 0.95em;
+    .examples {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 16px;
     }
 
-    pre {
-      overflow-x: auto;
-      margin: 14px 0 0;
-      padding: 16px;
-      border-radius: 8px;
-      background: var(--code-bg);
-      color: var(--code-text);
-      line-height: 1.5;
+    .example {
+      border: 1px solid var(--rule-dark);
+      background: var(--code-paper);
     }
 
-    pre code {
-      color: inherit;
-      font-size: 14px;
+    .example h3 {
+      margin: 0;
+      padding: 12px;
+      border-bottom: 1px solid var(--rule-dark);
+      background: var(--paper-deep);
+    }
+
+    .example p {
+      padding: 12px 12px 0;
+    }
+
+    .example .code-block {
+      margin: 12px;
+    }
+
+    .callout {
+      margin-top: 16px;
+      padding: 14px;
+      border-left: 8px solid var(--amber);
+      background: #fff1c7;
+    }
+
+    .danger {
+      border-left-color: var(--red);
+      background: #f6ddd7;
     }
 
     ul {
+      max-width: 78ch;
       margin: 10px 0 0;
       padding-left: 22px;
     }
@@ -284,216 +364,297 @@
     }
 
     footer {
-      padding: 28px 0 42px;
-      border-top: 1px solid var(--line);
-      color: var(--muted);
-      font-size: 14px;
+      padding: 24px 0 42px;
+      border-top: 2px solid var(--ink);
+      color: var(--ink-soft);
+      font-size: 13px;
     }
 
-    @media (max-width: 860px) {
-      .topbar,
-      .hero {
+    @media (prefers-reduced-motion: reduce) {
+      html {
+        scroll-behavior: auto;
+      }
+
+      .repo-link {
+        transition: none;
+      }
+    }
+
+    @media (max-width: 900px) {
+      .masthead-line,
+      .terminal-strip,
+      .layout {
         grid-template-columns: 1fr;
       }
 
-      .topbar {
-        align-items: flex-start;
+      .repo-link {
+        width: max-content;
       }
 
       nav {
-        justify-content: flex-start;
+        position: static;
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 0 16px;
+      }
+    }
+
+    @media (max-width: 620px) {
+      .page {
+        width: min(100% - 20px, 1180px);
       }
 
-      .hero {
-        padding-top: 36px;
-      }
-
-      .grid {
+      .quick-facts,
+      .examples,
+      nav {
         grid-template-columns: 1fr;
       }
 
+      .fact,
+      .fact:nth-child(2n),
+      .fact:nth-last-child(-n + 2) {
+        border-right: 0;
+        border-bottom: 1px solid var(--rule);
+      }
+
+      .fact:last-child {
+        border-bottom: 0;
+      }
+
       section {
-        padding: 22px;
+        padding: 20px;
       }
     }
   </style>
 </head>
 <body>
-  <header>
-    <div class="wrap">
-      <div class="topbar">
-        <div class="brand">
-          <div class="mark">de</div>
-          <span>direnv-action</span>
+  <header class="masthead">
+    <div class="page">
+      <div class="manual-id" aria-label="Document metadata">
+        <span>direnv-action(1)</span>
+        <span>GitHub Actions</span>
+        <span>v1.3.6</span>
+      </div>
+      <div class="masthead-line">
+        <div>
+          <h1>Evaluate .envrc inside CI.</h1>
+          <p class="tagline">
+            A compact action for installing direnv, exporting a trusted environment, validating required names,
+            and carrying those variables into later workflow steps.
+          </p>
         </div>
-        <nav aria-label="Primary navigation">
-          <a href="#quick-start">Quick start</a>
-          <a href="#inputs">Inputs</a>
-          <a href="#examples">Examples</a>
-          <a href="#troubleshooting">Troubleshooting</a>
-          <a href="#security">Security</a>
-        </nav>
+        <a class="repo-link" href="https://github.com/HatsuneMiku3939/direnv-action">Repository</a>
       </div>
 
-      <div class="hero">
-        <div>
-          <h1>Load direnv variables in GitHub Actions.</h1>
-          <p class="lead">
-            Install direnv, evaluate a trusted <code>.envrc</code>, export its environment variables to later workflow steps,
-            and mask selected secret values.
-          </p>
-          <div class="actions">
-            <a class="button" href="#quick-start">Start with YAML</a>
-            <a class="button secondary" href="https://github.com/HatsuneMiku3939/direnv-action">View on GitHub</a>
+      <div class="terminal-strip">
+        <div class="trace" aria-label="Example action trace">
+          <div class="trace-head">
+            <span>workflow trace</span>
+            <span>no values printed</span>
           </div>
+          <pre><code>$ direnv allow child
+<span class="ok">allowed .envrc</span>
+$ direnv export json
+<span class="ok">exported: CHILD_ENV, PATH, SECRET1</span>
+$ validate required
+<span class="ok">found: CHILD_ENV, SECRET1</span>
+$ mask secrets
+<span class="warn">redacted configured values</span></code></pre>
         </div>
 
-        <div class="flow" aria-label="direnv-action workflow">
-          <div class="flow-step"><span>1</span><strong>Install the requested direnv release</strong></div>
-          <div class="flow-step"><span>2</span><strong>Run direnv allow and export json</strong></div>
-          <div class="flow-step"><span>3</span><strong>Validate required variables and mask secrets</strong></div>
-          <div class="flow-step"><span>4</span><strong>Expose variables to later workflow steps</strong></div>
+        <div class="quick-facts" aria-label="Quick facts">
+          <div class="fact">
+            <strong>Runtime</strong>
+            Node 24 action, bundled in <code>dist/index.js</code>.
+          </div>
+          <div class="fact">
+            <strong>Source</strong>
+            Reads the selected directory's <code>.envrc</code>.
+          </div>
+          <div class="fact">
+            <strong>Output</strong>
+            Exports variables to later steps; custom outputs are not defined.
+          </div>
+          <div class="fact">
+            <strong>Safety</strong>
+            Use only with trusted repositories and trusted <code>.envrc</code> files.
+          </div>
         </div>
       </div>
     </div>
   </header>
 
-  <main class="wrap">
-    <section id="quick-start">
-      <h2>Quick Start</h2>
-      <p>
-        Pin an exact release for predictable builds, or use <code>@v1</code> to receive compatible updates within the
-        current major version.
-      </p>
-      <pre><code>steps:
+  <div class="page layout">
+    <nav aria-label="Page sections">
+      <a href="#quick-start">Quick start</a>
+      <a href="#inputs">Inputs</a>
+      <a href="#examples">Examples</a>
+      <a href="#troubleshooting">Troubleshooting</a>
+      <a href="#security">Security</a>
+      <a href="#maintainers">Maintainers</a>
+    </nav>
+
+    <main>
+      <section id="quick-start">
+        <span class="section-kicker">Start here</span>
+        <h2>Minimal workflow</h2>
+        <p>
+          Pin an exact release for repeatable builds. Use <code>@v1</code> only when the workflow should receive
+          compatible updates automatically.
+        </p>
+        <div class="code-block">
+          <div class="code-label">.github/workflows/example.yml</div>
+          <pre><code>steps:
   - uses: actions/checkout@v7
   - uses: HatsuneMiku3939/direnv-action@v1.3.6
     with:
       direnvVersion: 2.37.1
       masks: SECRET1, SECRET2</code></pre>
-    </section>
+        </div>
+        <div class="callout">
+          This action logs exported variable names for debugging, but it does not print environment variable values.
+        </div>
+      </section>
 
-    <section id="inputs">
-      <h2>Inputs</h2>
-      <table>
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Default</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><code>direnvVersion</code></td>
-            <td><code>2.37.1</code></td>
-            <td>The direnv version to install from GitHub release assets or cache.</td>
-          </tr>
-          <tr>
-            <td><code>masks</code></td>
-            <td><code>''</code></td>
-            <td>Comma-separated environment variable names whose exported values should be masked in logs.</td>
-          </tr>
-          <tr>
-            <td><code>required</code></td>
-            <td><code>''</code></td>
-            <td>Newline-delimited environment variable names that must be present after <code>direnv export json</code>.</td>
-          </tr>
-          <tr>
-            <td><code>path</code></td>
-            <td><code>.</code></td>
-            <td>Directory where <code>direnv allow</code> and <code>direnv export json</code> are executed.</td>
-          </tr>
-        </tbody>
-      </table>
-    </section>
+      <section id="inputs">
+        <span class="section-kicker">Contract</span>
+        <h2>Inputs</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Default</th>
+              <th>Use it for</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>direnvVersion</code></td>
+              <td><code>2.37.1</code></td>
+              <td>Selecting the direnv binary version installed from release assets or cache.</td>
+            </tr>
+            <tr>
+              <td><code>masks</code></td>
+              <td><code>''</code></td>
+              <td>Comma-separated environment variable names whose exported values should be redacted from logs.</td>
+            </tr>
+            <tr>
+              <td><code>required</code></td>
+              <td><code>''</code></td>
+              <td>Newline-delimited environment variable names that must exist after <code>direnv export json</code>.</td>
+            </tr>
+            <tr>
+              <td><code>path</code></td>
+              <td><code>.</code></td>
+              <td>Directory where <code>direnv allow</code> and <code>direnv export json</code> run.</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
 
-    <section id="examples">
-      <h2>Examples</h2>
-      <div class="grid">
-        <div class="input-card">
-          <strong>Pin a direnv version</strong>
-          <p>Use <code>direnvVersion</code> when workflows need a known direnv binary.</p>
-          <pre><code>- uses: HatsuneMiku3939/direnv-action@v1.3.6
+      <section id="examples">
+        <span class="section-kicker">Patterns</span>
+        <h2>Common configurations</h2>
+        <div class="examples">
+          <article class="example">
+            <h3>Pin direnv</h3>
+            <p>Use a known direnv version when workflow behavior must stay stable.</p>
+            <div class="code-block">
+              <div class="code-label">direnvVersion</div>
+              <pre><code>- uses: HatsuneMiku3939/direnv-action@v1.3.6
   with:
     direnvVersion: 2.37.1</code></pre>
-        </div>
-        <div class="input-card">
-          <strong>Mask secret values</strong>
-          <p><code>masks</code> takes variable names, not raw secret values.</p>
-          <pre><code>- uses: HatsuneMiku3939/direnv-action@v1.3.6
+            </div>
+          </article>
+
+          <article class="example">
+            <h3>Mask secrets</h3>
+            <p>List exported variable names. Do not paste raw secret values into <code>masks</code>.</p>
+            <div class="code-block">
+              <div class="code-label">masks</div>
+              <pre><code>- uses: HatsuneMiku3939/direnv-action@v1.3.6
   with:
     masks: SECRET1, SECRET2</code></pre>
-        </div>
-        <div class="input-card">
-          <strong>Require exported variables</strong>
-          <p>Fail early when expected environment variables are missing.</p>
-          <pre><code>- uses: HatsuneMiku3939/direnv-action@v1.3.6
+            </div>
+          </article>
+
+          <article class="example">
+            <h3>Require names</h3>
+            <p>Fail the step before exporting anything when expected variables are missing.</p>
+            <div class="code-block">
+              <div class="code-label">required</div>
+              <pre><code>- uses: HatsuneMiku3939/direnv-action@v1.3.6
   with:
     required: |
       AWS_REGION
       DATABASE_URL
       NODE_AUTH_TOKEN</code></pre>
-        </div>
-        <div class="input-card">
-          <strong>Evaluate a subdirectory</strong>
-          <p>Set <code>path</code> when the target <code>.envrc</code> is not at the repository root.</p>
-          <pre><code>- uses: HatsuneMiku3939/direnv-action@v1.3.6
+            </div>
+          </article>
+
+          <article class="example">
+            <h3>Use a subdirectory</h3>
+            <p>Point <code>path</code> at the directory containing the target <code>.envrc</code>.</p>
+            <div class="code-block">
+              <div class="code-label">path</div>
+              <pre><code>- uses: HatsuneMiku3939/direnv-action@v1.3.6
   with:
     path: child</code></pre>
+            </div>
+          </article>
         </div>
-      </div>
-    </section>
+      </section>
 
-    <section id="troubleshooting">
-      <h2>Troubleshooting</h2>
-      <h3>Required variables are missing</h3>
-      <p>
-        Check that the selected <code>path</code> contains the expected <code>.envrc</code> and that
-        <code>direnv export json</code> actually exports each name listed in <code>required</code>.
-      </p>
-      <h3>Secret values still appear in logs</h3>
-      <p>
-        Confirm that <code>masks</code> lists variable names such as <code>SECRET1</code>, not the secret values themselves.
-      </p>
-      <h3>PATH changes are not visible</h3>
-      <p>
-        When <code>.envrc</code> exports <code>PATH</code>, the action appends it through the GitHub Actions path API for
-        later workflow steps in the same job.
-      </p>
-    </section>
-
-    <section id="security">
-      <h2>Security Considerations</h2>
-      <div class="note warning">
+      <section id="troubleshooting">
+        <span class="section-kicker">When it fails</span>
+        <h2>Troubleshooting</h2>
+        <h3>Required variables are missing</h3>
         <p>
-          This action evaluates <code>.envrc</code>. Only run it with trusted repositories and trusted
-          <code>.envrc</code> contents, especially when workflow secrets are available.
+          Check that <code>path</code> points at the intended <code>.envrc</code> and that
+          <code>direnv export json</code> exports every name listed in <code>required</code>.
         </p>
-      </div>
-      <ul>
-        <li>Review fork-based pull request workflows before running this action with secrets.</li>
-        <li>Treat masking as log redaction, not as a complete secret protection boundary.</li>
-        <li>Keep sensitive logic inside trusted workflow contexts whenever possible.</li>
-      </ul>
-    </section>
+        <h3>Secret values still appear</h3>
+        <p>
+          Confirm <code>masks</code> contains variable names such as <code>SECRET1</code>, not the secret values.
+        </p>
+        <h3>PATH changes are not visible</h3>
+        <p>
+          When <code>.envrc</code> exports <code>PATH</code>, the action appends it through the GitHub Actions path API.
+          Later steps in the same job receive the updated path.
+        </p>
+      </section>
 
-    <section id="maintenance">
-      <h2>Maintainer Notes</h2>
-      <p>
-        This site is intended to stay lightweight. Keep its usage guidance aligned with <code>README.md</code> and
-        <code>action.yml</code>.
-      </p>
-      <p>
-        Publish it from GitHub repository settings with <strong>Settings -> Pages -> Deploy from a branch</strong>,
-        using branch <code>master</code> and folder <code>/docs</code>.
-      </p>
-    </section>
-  </main>
+      <section id="security">
+        <span class="section-kicker">Trust boundary</span>
+        <h2>Security</h2>
+        <div class="callout danger">
+          <code>.envrc</code> is executable project configuration. Treat it as code, especially in workflows that can access secrets.
+        </div>
+        <ul>
+          <li>Run this action only with trusted repositories and trusted <code>.envrc</code> contents.</li>
+          <li>Review fork-based pull request workflows before exposing secrets.</li>
+          <li>Use masking as log redaction, not as a complete secret-protection boundary.</li>
+          <li>Keep sensitive logic inside trusted workflow contexts whenever possible.</li>
+        </ul>
+      </section>
+
+      <section id="maintainers">
+        <span class="section-kicker">Publishing</span>
+        <h2>Maintainers</h2>
+        <p>
+          This site is published from GitHub Pages using branch <code>master</code> and folder <code>/docs</code>.
+          Keep this page aligned with <code>README.md</code> and <code>action.yml</code>.
+        </p>
+        <p>
+          When preparing a release that changes the exact pinned tag, update both <code>README.md</code> and this page.
+        </p>
+      </section>
+    </main>
+  </div>
 
   <footer>
-    <div class="wrap">
-      <span>Documentation for HatsuneMiku3939/direnv-action.</span>
+    <div class="page">
+      direnv-action documentation. Source: <a href="https://github.com/HatsuneMiku3939/direnv-action">HatsuneMiku3939/direnv-action</a>.
     </div>
   </footer>
 </body>


### PR DESCRIPTION
## Summary

- Redesign the GitHub Pages documentation as a sharper CI/manual-style reference page.
- Replace the generic card-heavy look with a terminal trace, dense reference layout, sticky section navigation, and restrained documentation-focused styling.
- Add a canonical link while preserving the existing usage coverage.

## Background

The first Pages design read too much like an AI-generated template. This update uses the newly installed `frontend-design` Codex skill from AI UX Playground / Anthropic frontend-design guidance to make the page more subject-specific and less generic.

## Related issue(s)

Related to #375.

## Implementation details

- Reworked `docs/index.html` as a single static HTML file with no JavaScript framework.
- Grounded the visual direction in terminal logs, man-page structure, and GitHub Actions workflow references.
- Kept quick start, inputs, examples, troubleshooting, security, and maintainer notes.
- Added responsive layout, visible focus styles, and reduced-motion handling.

## Test coverage

- `npm run all`
- `npm audit`
- `git diff --check`
- Local static server smoke test with HTTP 200 for `docs/index.html`

## Breaking changes

None.

## Notes

Playwright is not installed in this repository, so screenshot validation was not run.

Created by Codex
