### PR TITLE
[codex] Expand security guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,19 @@ For the most predictable builds, pin an exact version tag such as `@v1.3.7`. Use
 
 ## Security considerations
 
-This action evaluates `.envrc`, which means repository code can influence the shell commands executed by `direnv`.
+This action evaluates `.envrc`, which means repository code can influence the shell commands executed by `direnv`. Treat
+`.envrc` as executable code, especially in workflows that can access repository secrets, cloud credentials, deployment
+tokens, or production infrastructure.
 
 - Only use this action with trusted repositories and trusted `.envrc` contents.
-- Review fork-based pull request workflows carefully before allowing this action to run with secrets.
+- Avoid evaluating untrusted fork contents from `pull_request_target` workflows. If you use `pull_request_target`, do not
+  check out and run a fork-provided `.envrc` in a job that has access to secrets.
+- Prefer running secret-bearing jobs only on trusted refs, protected branches, or reviewed tags. For fork PR validation,
+  use `pull_request` with minimal permissions and without repository secrets unless the `.envrc` contents are trusted.
+- Use the `required` input to fail early when expected exported variables are missing. This helps prevent downstream steps
+  from running with incomplete configuration, but it is not a sandbox or a secret-protection boundary.
+- Keep workflow `permissions:` as narrow as possible and avoid passing long-lived credentials into jobs that evaluate
+  changing `.envrc` files.
 - Treat masking as a log redaction aid, not a complete secret protection boundary.
 - Keep sensitive logic inside trusted workflow contexts whenever possible.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -628,12 +628,31 @@ $ mask secrets
         <span class="section-kicker">Trust boundary</span>
         <h2>Security</h2>
         <div class="callout danger">
-          <code>.envrc</code> is executable project configuration. Treat it as code, especially in workflows that can access secrets.
+          <code>.envrc</code> is executable project configuration. Treat it as code, especially in workflows that can access
+          repository secrets, cloud credentials, deployment tokens, or production infrastructure.
         </div>
         <ul>
           <li>Run this action only with trusted repositories and trusted <code>.envrc</code> contents.</li>
-          <li>Review fork-based pull request workflows before exposing secrets.</li>
-          <li>Use masking as log redaction, not as a complete secret-protection boundary.</li>
+          <li>
+            Avoid evaluating untrusted fork contents from <code>pull_request_target</code> workflows. If you use
+            <code>pull_request_target</code>, do not check out and run a fork-provided <code>.envrc</code> in a job that
+            has access to secrets.
+          </li>
+          <li>
+            Prefer running secret-bearing jobs only on trusted refs, protected branches, or reviewed tags. For fork PR
+            validation, use <code>pull_request</code> with minimal permissions and without repository secrets unless the
+            <code>.envrc</code> contents are trusted.
+          </li>
+          <li>
+            Use the <code>required</code> input to fail early when expected exported variables are missing. This helps
+            prevent downstream steps from running with incomplete configuration, but it is not a sandbox or a
+            secret-protection boundary.
+          </li>
+          <li>
+            Keep workflow <code>permissions:</code> as narrow as possible and avoid passing long-lived credentials into
+            jobs that evaluate changing <code>.envrc</code> files.
+          </li>
+          <li>Use masking as log redaction, not as a complete secret protection boundary.</li>
           <li>Keep sensitive logic inside trusted workflow contexts whenever possible.</li>
         </ul>
       </section>


### PR DESCRIPTION
## Summary

- Expanded the README security guidance for workflows that evaluate `.envrc`.
- Updated the GitHub Pages documentation security section with the same guidance.

## Background

The action evaluates `.envrc`, so users need clearer guidance for fork PR workflows, secret-bearing jobs, trusted refs, and validation boundaries.

## Related issue(s)

None.

## Implementation details

- Clarified `pull_request_target` risks when evaluating fork-provided `.envrc` files.
- Recommended trusted refs/protected branches/reviewed tags for jobs with secrets.
- Documented `required` as a fail-fast configuration guard, not a sandbox or secret boundary.
- Added a least-privilege `permissions:` reminder.

## Test coverage

- `npm run lint`
- `npm test`

## Breaking changes

None.

## Notes

Created by Codex
