### PR TITLE
docs: add dependents badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 
 [![test](https://github.com/HatsuneMiku3939/direnv-action/actions/workflows/test.yaml/badge.svg)](https://github.com/HatsuneMiku3939/direnv-action/actions/workflows/test.yaml)
 [![CodeQL](https://github.com/HatsuneMiku3939/direnv-action/actions/workflows/codeql.yml/badge.svg)](https://github.com/HatsuneMiku3939/direnv-action/actions/workflows/codeql.yml)
+[![Dependents](https://dependents.info/HatsuneMiku3939/direnv-action/badge)](https://dependents.info/HatsuneMiku3939/direnv-action)
 
 
 # direnv action
@@ -12,6 +13,10 @@ evaluates the target `.envrc`, and exports the resulting environment variables
 to subsequent workflow steps.
 
 Documentation site: https://hatsunemiku3939.github.io/direnv-action/
+
+## Who uses this action
+
+[![Repositories that depend on direnv-action](https://dependents.info/HatsuneMiku3939/direnv-action/image)](https://dependents.info/HatsuneMiku3939/direnv-action)
 
 ## How it works
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -125,6 +125,24 @@
       box-shadow: 3px 3px 0 var(--ink);
     }
 
+    .masthead-actions {
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+      align-items: flex-end;
+    }
+
+    .dependents-badge {
+      display: inline-block;
+      line-height: 0;
+    }
+
+    .dependents-badge img {
+      display: block;
+      height: 20px;
+      max-width: 100%;
+    }
+
     .terminal-strip {
       display: grid;
       grid-template-columns: 1.05fr 0.95fr;
@@ -353,6 +371,15 @@
       background: #f6ddd7;
     }
 
+    .dependents-image {
+      display: block;
+      width: min(100%, 688px);
+      height: auto;
+      margin-top: 16px;
+      border: 1px solid var(--rule-dark);
+      background: var(--code-paper);
+    }
+
     ul {
       max-width: 78ch;
       margin: 10px 0 0;
@@ -389,6 +416,10 @@
 
       .repo-link {
         width: max-content;
+      }
+
+      .masthead-actions {
+        align-items: flex-start;
       }
 
       nav {
@@ -443,7 +474,12 @@
             and carrying those variables into later workflow steps.
           </p>
         </div>
-        <a class="repo-link" href="https://github.com/HatsuneMiku3939/direnv-action">Repository</a>
+        <div class="masthead-actions">
+          <a class="repo-link" href="https://github.com/HatsuneMiku3939/direnv-action">Repository</a>
+          <a class="dependents-badge" href="https://dependents.info/HatsuneMiku3939/direnv-action" aria-label="View direnv-action dependents">
+            <img src="https://dependents.info/HatsuneMiku3939/direnv-action/badge" alt="GitHub network dependents">
+          </a>
+        </div>
       </div>
 
       <div class="terminal-strip">
@@ -487,6 +523,7 @@ $ mask secrets
   <div class="page layout">
     <nav aria-label="Page sections">
       <a href="#quick-start">Quick start</a>
+      <a href="#who-uses">Who uses this action</a>
       <a href="#inputs">Inputs</a>
       <a href="#examples">Examples</a>
       <a href="#troubleshooting">Troubleshooting</a>
@@ -514,6 +551,17 @@ $ mask secrets
         <div class="callout">
           This action logs exported variable names for debugging, but it does not print environment variable values.
         </div>
+      </section>
+
+      <section id="who-uses">
+        <span class="section-kicker">Dependency graph</span>
+        <h2>Who uses this action</h2>
+        <p>
+          dependents.info renders public GitHub dependency graph dependents for this repository.
+        </p>
+        <a href="https://dependents.info/HatsuneMiku3939/direnv-action">
+          <img class="dependents-image" src="https://dependents.info/HatsuneMiku3939/direnv-action/image" alt="Repositories that depend on direnv-action">
+        </a>
       </section>
 
       <section id="inputs">


### PR DESCRIPTION
## Summary

Adds dependents.info visibility to the README and GitHub Pages documentation.

## Background

The repository can show GitHub dependency graph dependents through dependents.info, since GitHub does not provide a native README badge for that count.

## Related issue(s)

None.

## Implementation details

- Adds a dependents.info badge to the top README badge block.
- Adds the same linked badge to the documentation site masthead below the repository link.
- Adds a `Who uses this action` section to the README with the dependents.info embed image.
- Adds a matching `Who uses this action` section to the GitHub Pages documentation.
- Adds responsive masthead action styling and embed image styling for the Pages layout.

## Test coverage

- `npm run lint`
- `npm test`
- Verified the dependents.info badge endpoint returns `200` with `image/svg+xml`.
- Verified the dependents.info embed image endpoint returns `200` with `image/svg+xml`.

## Breaking changes

None.

## Notes

Created by Codex