### PR TITLE
docs(release): add automated patch release workflow

### DIFF
--- a/.agents/skills/direnv-action-release/SKILL.md
+++ b/.agents/skills/direnv-action-release/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: direnv-action-release
-description: Prepare and publish a release for the direnv-action repository when the user asks for a patch, minor, or major release, wants the RELEASE_RUNBOOK followed, or needs the version tag, GitHub Release, and moving v1 tag updated together.
+description: Classify, prepare, and publish direnv-action releases through either an explicitly requested manual flow or an explicitly authorized release-preparation PR handoff after a verified Dependabot merge. Use for patch, minor, or major releases, release-set review, automated patch-release evaluation, version/tag publication, GitHub Releases, and moving v1 updates.
 ---
 
 # direnv-action Release
 
-Use this skill when the user asks to release `direnv-action`, bump the release version, or publish a new `v1.x.y` tag.
+Keep `master`, immutable version tags, GitHub Releases, and the moving `v1` tag
+consistent while preserving the caller's write authority.
 
 ## Required Context
 
@@ -13,17 +14,52 @@ Use this skill when the user asks to release `direnv-action`, bump the release v
 - Read `RELEASE_RUNBOOK.md` for the canonical release flow.
 - Read [`references/release-flow.md`](./references/release-flow.md) for the command checklist.
 - Read [`references/release-guardrails.md`](./references/release-guardrails.md) before pushing or retagging.
+- Read [`references/release-eligibility.md`](./references/release-eligibility.md)
+  before an automatic patch-release handoff.
 
-## Workflow
+## Write Authority
 
-1. Confirm the working tree is clean and `master` is up to date.
-2. Determine the next version from the requested release type and the latest `v*` tag.
-3. Update the version with `npm version <version> --no-git-tag-version`.
-4. Update release-facing documentation that pins an exact version tag, including both `README.md` and `docs/index.html`.
-5. Run the full validation gate with `nvm use`, `npm ci`, and `npm run all`.
-6. Commit the release-preparation changes to `master` with a Conventional Commit message.
-7. Push `master`, create the annotated version tag, and publish the GitHub Release.
-8. Force-move the `v1` tag to the same commit and verify both tags resolve to the release commit.
+- Treat release-set and version inspection as read-only.
+- Use the manual flow only when the user explicitly asks to publish a release.
+- Use the automated patch flow only when a trusted operator prompt explicitly
+  authorizes the release branch, preparation PR, exact-head merge, immutable
+  patch tag, GitHub Release, and moving `v1` update.
+- Never infer release authority from a merged dependency PR, changed `dist`, or
+  skill invocation alone.
+- Stop automatic publication for minor, major, breaking, unclassified, or
+  medium/high-risk release sets.
+- Honor newer constraints such as `read only` or `do not release`.
+
+## Select the Flow
+
+### Manual release
+
+Follow the existing manual path in `RELEASE_RUNBOOK.md` for an explicitly
+requested patch, minor, or major release. Direct `master` push remains a manual
+operator path only.
+
+### Authorized automatic patch release
+
+1. Confirm the verified dependency merge and classify every commit after the
+   latest immutable version tag.
+2. Return `release_not_required` or `release_held` when the eligibility reference
+   requires it.
+3. Detect an existing matching release branch, PR, tag, or GitHub Release before
+   creating anything.
+4. Prepare the next patch version in a dedicated `release/v1.x.y` worktree.
+5. Update version files, `README.md`, and `docs/index.html`; run `nvm use`,
+   `npm ci`, `npm run all`, full and production audits, and diff checks.
+6. Commit and open a non-draft release-preparation PR using the repository PR
+   body contract. Run the standard reviewer procedure and wait for current CI.
+7. Re-check the exact release PR head before merge, use a merge commit, and
+   verify the merge read-back.
+8. Publish the annotated immutable tag and GitHub Release from the exact release
+   merge commit, then move `v1` and verify all peeled targets.
+
+Re-check the relevant remote ref, PR head, tag, or Release immediately before
+every external write. On a partial failure, report the last verified state and
+stop; never delete an immutable tag or Release, undo the dependency merge, or
+repeat a successful write blindly.
 
 ## Output Expectations
 
@@ -32,5 +68,8 @@ Report:
 - the chosen release version
 - validation commands that passed
 - the release-preparation commit SHA
+- the release-preparation PR and exact merge commit when that flow is used
 - the version tag and GitHub Release URL
 - whether `v1` now points to the same commit
+- the terminal state: `release_not_required`, `release_held`,
+  `release_prepared`, `release_published`, or `release_partial_failure`

--- a/.agents/skills/direnv-action-release/SKILL.md
+++ b/.agents/skills/direnv-action-release/SKILL.md
@@ -54,7 +54,9 @@ operator path only.
 7. Re-check the exact release PR head before merge, use a merge commit, and
    verify the merge read-back.
 8. Publish the annotated immutable tag and GitHub Release from the exact release
-   merge commit, then move `v1` and verify all peeled targets.
+   merge commit. Move `v1` with a raw tag-object compare-and-swap, retaining a
+   concurrently published strictly newer compatible target, then verify all
+   refs and the Release.
 
 Re-check the relevant remote ref, PR head, tag, or Release immediately before
 every external write. On a partial failure, report the last verified state and
@@ -70,6 +72,7 @@ Report:
 - the release-preparation commit SHA
 - the release-preparation PR and exact merge commit when that flow is used
 - the version tag and GitHub Release URL
-- whether `v1` now points to the same commit
+- whether `v1` points to the release commit or a verified strictly newer
+  compatible immutable release
 - the terminal state: `release_not_required`, `release_held`,
   `release_prepared`, `release_published`, or `release_partial_failure`

--- a/.agents/skills/direnv-action-release/references/release-eligibility.md
+++ b/.agents/skills/direnv-action-release/references/release-eligibility.md
@@ -1,0 +1,49 @@
+# Automatic patch-release eligibility
+
+Use this contract only for a trusted automatic handoff after a verified
+Dependabot merge. Do not use it to broaden the Dependabot merge-risk policy.
+
+## Require all conditions
+
+- The original PR was merged inside its authorized unattended risk boundary.
+- Merge read-back proves the verified PR head is a parent of the merge commit.
+- The latest immutable version tag and its peeled commit are unambiguous.
+- Every commit after that tag through the verified merge commit maps to a reviewed
+  PR or an already verified release-safe commit.
+- The complete release set is patch SemVer: no breaking change, new input/output,
+  behavior contract expansion, or required migration.
+- The set changes a shipped runtime surface: `dist/**`, `action.yml`, a production
+  dependency included in `dist`, or a runtime security fix delivered by a tag.
+- No install script, maintainer/releaser warning, auth/proxy/network/request-path
+  change, unexpected generated artifact, or failing gate exists.
+
+Return `release_not_required` when changes are limited to dev-only lockfile,
+lint, test, CI, or documentation updates and committed runtime artifacts are
+unchanged.
+
+Return `release_held` when any commit is unclassified, the release set includes a
+medium/high-risk change, patch SemVer is uncertain, a matching release artifact
+conflicts, or a required gate cannot be proven current.
+
+## Version and collision checks
+
+- Parse the highest immutable `v1.x.y` tag and increment only its patch component.
+- Require `package.json` and `package-lock.json` to match the current released
+  version before preparing the next one.
+- Search local and remote refs, open and closed PRs, and GitHub Releases for the
+  intended branch and version.
+- Reuse an exact in-progress preparation. Hold on any conflicting branch, PR,
+  tag, or Release; never overwrite it.
+
+## Required evidence
+
+- release-set commit and PR inventory;
+- exact source `origin/master` SHA;
+- Node and npm versions from `.nvmrc`;
+- clean `npm ci`, `npm run all`, `npm audit`, `npm audit --omit=dev`, and
+  `git diff --check`;
+- expected file set for the release preparation;
+- reviewer findings and exact-head GitHub CI;
+- release PR merge commit and parent relationship;
+- peeled `origin/master`, immutable tag, and `v1` targets plus GitHub Release
+  read-back.

--- a/.agents/skills/direnv-action-release/references/release-eligibility.md
+++ b/.agents/skills/direnv-action-release/references/release-eligibility.md
@@ -12,14 +12,18 @@ Dependabot merge. Do not use it to broaden the Dependabot merge-risk policy.
   PR or an already verified release-safe commit.
 - The complete release set is patch SemVer: no breaking change, new input/output,
   behavior contract expansion, or required migration.
-- The set changes a shipped runtime surface: `dist/**`, `action.yml`, a production
-  dependency included in `dist`, or a runtime security fix delivered by a tag.
+- The set changes a shipped runtime surface because of a source, `action.yml`,
+  production-dependency, or runtime-security change. Generated `dist/**` is
+  evidence of that source change, not an independent reason to release.
 - No install script, maintainer/releaser warning, auth/proxy/network/request-path
   change, unexpected generated artifact, or failing gate exists.
 
-Return `release_not_required` when changes are limited to dev-only lockfile,
-lint, test, CI, or documentation updates and committed runtime artifacts are
-unchanged.
+Classify the cause before generated effects. Return `release_not_required` when
+changes are limited to dev-only lockfile, lint, test, CI, or documentation
+updates and committed runtime artifacts are unchanged. Return `release_held`
+when a dev-only tool change regenerates `dist/**`, or when a bundler or releaser
+change appears anywhere in the release set; do not treat generated output as a
+way around the original risk boundary.
 
 Return `release_held` when any commit is unclassified, the release set includes a
 medium/high-risk change, patch SemVer is uncertain, a matching release artifact
@@ -34,6 +38,11 @@ conflicts, or a required gate cannot be proven current.
   intended branch and version.
 - Reuse an exact in-progress preparation. Hold on any conflicting branch, PR,
   tag, or Release; never overwrite it.
+- Before moving `v1`, record both its raw remote tag-object OID and peeled target.
+  Treat an exact intended target as complete, retain a strictly newer compatible
+  immutable tag with a matching GitHub Release, and hold on any other target.
+  Update only with a raw-OID `--force-with-lease`; never use an unconditional
+  force push.
 
 ## Required evidence
 
@@ -45,5 +54,5 @@ conflicts, or a required gate cannot be proven current.
 - expected file set for the release preparation;
 - reviewer findings and exact-head GitHub CI;
 - release PR merge commit and parent relationship;
-- peeled `origin/master`, immutable tag, and `v1` targets plus GitHub Release
-  read-back.
+- peeled `origin/master`, immutable tag, and `v1` targets plus the raw `v1` tag
+  object and GitHub Release read-back.

--- a/.agents/skills/direnv-action-release/references/release-eligibility.md
+++ b/.agents/skills/direnv-action-release/references/release-eligibility.md
@@ -55,4 +55,6 @@ conflicts, or a required gate cannot be proven current.
 - reviewer findings and exact-head GitHub CI;
 - release PR merge commit and parent relationship;
 - peeled `origin/master`, immutable tag, and `v1` targets plus the raw `v1` tag
-  object and GitHub Release read-back.
+  object and GitHub Release read-back. Final `v1` evidence must come from fresh
+  remote refs and map to exactly one compatible immutable version tag on
+  `master` with a non-draft, non-prerelease Release.

--- a/.agents/skills/direnv-action-release/references/release-flow.md
+++ b/.agents/skills/direnv-action-release/references/release-flow.md
@@ -29,8 +29,10 @@ Use this checklist after reading `RELEASE_RUNBOOK.md`.
    - `git push origin <next-version-tag>`
    - `gh release create <next-version-tag> --title "<next-version-tag>" --generate-notes`
 8. Move the major tag:
+   - record the current raw remote tag-object OID with
+     `git ls-remote origin refs/tags/v1`
    - `git tag -fa v1 -m "Update v1 to <next-version-tag>"`
-   - `git push origin refs/tags/v1 --force`
+   - `git push --force-with-lease=refs/tags/v1:<expected-raw-tag-object> origin refs/tags/v1`
 9. Verify:
    - `git rev-list -n 1 <next-version-tag>`
    - `git rev-list -n 1 v1`
@@ -70,6 +72,10 @@ Use this checklist after reading `RELEASE_RUNBOOK.md`.
 9. Require `origin/master` to equal the exact release merge commit before
    creating the annotated immutable tag.
 10. Re-check tag absence, push the immutable tag, and create the GitHub Release.
-11. Re-check the old remote `v1` peeled target, move it to the release commit,
-    and verify default branch, immutable tag, `v1`, and Release together.
+11. Re-check the old remote `v1` raw tag-object OID and peeled target. If it
+    already targets the intended release, continue. If it targets a strictly
+    newer compatible immutable release, retain it and continue. Hold on any
+    other target. Otherwise move it with
+    `--force-with-lease=refs/tags/v1:<expected-raw-tag-object>` and verify the
+    default branch, immutable tag, `v1`, and Release together.
 12. Clean the merged release worktree and local branch without force deletion.

--- a/.agents/skills/direnv-action-release/references/release-flow.md
+++ b/.agents/skills/direnv-action-release/references/release-flow.md
@@ -2,6 +2,8 @@
 
 Use this checklist after reading `RELEASE_RUNBOOK.md`.
 
+## Manual operator flow
+
 1. Sync local state:
    - `git checkout master`
    - `git fetch --all --tags`
@@ -33,3 +35,41 @@ Use this checklist after reading `RELEASE_RUNBOOK.md`.
    - `git rev-list -n 1 <next-version-tag>`
    - `git rev-list -n 1 v1`
    - `gh release view <next-version-tag>`
+
+## Authorized automatic patch flow
+
+1. Verify handoff and release set:
+   - prove the dependency PR merge and parents;
+   - inventory `<last-version-tag>..origin/master` and linked PRs;
+   - apply `release-eligibility.md` and stop on no-op or hold.
+2. Check collisions:
+   - local and remote `release/<next-version-tag>` refs;
+   - open and closed matching release PRs;
+   - local and remote immutable tag, GitHub Release, and moving `v1`.
+3. Prepare from exact `origin/master` in a dedicated worktree:
+   - `npm ci`
+   - `npm run all`
+   - `npm version <next-version> --no-git-tag-version`
+   - update `README.md` and `docs/index.html`
+   - `npm run all`
+   - `npm audit`
+   - `npm audit --omit=dev`
+   - `git diff --check`
+4. Commit and publish the preparation branch:
+   - stage only `package.json`, `package-lock.json`, `README.md`,
+     `docs/index.html`, and expected regenerated `dist` files;
+   - commit `chore(release): prepare <next-version-tag>`;
+   - re-check the source branch ref, then push the release branch.
+5. Open a non-draft PR with the required repository body sections and
+   `Created by Codex`; apply the appropriate release or maintenance label.
+6. Run the standard reviewer procedure, address authorized findings, and wait
+   for exact-head GitHub CI.
+7. Re-check base, exact head, CI, version collision state, and release-set
+   eligibility immediately before merge; merge with a merge commit.
+8. Read back the release PR merge and fast-forward local `master`.
+9. Require `origin/master` to equal the exact release merge commit before
+   creating the annotated immutable tag.
+10. Re-check tag absence, push the immutable tag, and create the GitHub Release.
+11. Re-check the old remote `v1` peeled target, move it to the release commit,
+    and verify default branch, immutable tag, `v1`, and Release together.
+12. Clean the merged release worktree and local branch without force deletion.

--- a/.agents/skills/direnv-action-release/references/release-flow.md
+++ b/.agents/skills/direnv-action-release/references/release-flow.md
@@ -76,6 +76,10 @@ Use this checklist after reading `RELEASE_RUNBOOK.md`.
     already targets the intended release, continue. If it targets a strictly
     newer compatible immutable release, retain it and continue. Hold on any
     other target. Otherwise move it with
-    `--force-with-lease=refs/tags/v1:<expected-raw-tag-object>` and verify the
-    default branch, immutable tag, `v1`, and Release together.
-12. Clean the merged release worktree and local branch without force deletion.
+    `--force-with-lease=refs/tags/v1:<expected-raw-tag-object>`.
+12. After a compare-and-swap or newer-target retention, read the remote
+    `master`, raw and peeled `v1`, and matching immutable version refs again.
+    Require exactly one compatible `v1.x.y` tag at the peeled target, prove its
+    SemVer is at least the intended version and its commit is on `master`, then
+    read back that tag's non-draft, non-prerelease GitHub Release.
+13. Clean the merged release worktree and local branch without force deletion.

--- a/.agents/skills/direnv-action-release/references/release-guardrails.md
+++ b/.agents/skills/direnv-action-release/references/release-guardrails.md
@@ -6,6 +6,9 @@
 - Use the Node version from `.nvmrc`.
 - Classify every commit since the latest immutable version tag before automatic
   patch preparation. Hold on unclassified or non-patch-safe commits.
+- Classify the source change before generated `dist/**`. A dev-only tool must not
+  become release-eligible merely because it regenerates committed artifacts;
+  bundler and releaser changes always hold the automatic path.
 - Always run `npm run all` after the version bump.
 - Do not hand-edit `dist/`; regenerate it through `npm run prepare` as part of `npm run all`.
 - Update both `README.md` and `docs/index.html` when they pin the latest exact release tag.
@@ -14,7 +17,11 @@
   reuse exact matches and stop on conflicts.
 - Re-check the affected ref or exact PR head before every remote write.
 - Publish both the immutable version tag and the moving `v1` tag.
-- Verify `v1` and the version tag resolve to the same commit before finishing.
+- Move `v1` only with a raw tag-object `--force-with-lease`. If another writer
+  advances it to a strictly newer compatible immutable release, retain that
+  target; hold on any other unexpected target.
+- Verify `v1` resolves to the intended release commit or a strictly newer
+  compatible immutable release before finishing.
 - If pushing to `master` shows a branch-rule warning but the push succeeds, report that explicitly.
 - Never delete an immutable tag or GitHub Release automatically after a partial
   failure. Report the last verified state and stop.

--- a/.agents/skills/direnv-action-release/references/release-guardrails.md
+++ b/.agents/skills/direnv-action-release/references/release-guardrails.md
@@ -1,11 +1,20 @@
 # Release Guardrails
 
 - `master` is the release source of truth. Do not create the release from an outdated branch.
+- Treat direct `master` push as a manual operator path only. An automatic patch
+  handoff must use a dedicated release-preparation PR.
 - Use the Node version from `.nvmrc`.
+- Classify every commit since the latest immutable version tag before automatic
+  patch preparation. Hold on unclassified or non-patch-safe commits.
 - Always run `npm run all` after the version bump.
 - Do not hand-edit `dist/`; regenerate it through `npm run prepare` as part of `npm run all`.
 - Update both `README.md` and `docs/index.html` when they pin the latest exact release tag.
 - Use a Conventional Commit message for the release-preparation commit.
+- Detect existing release branches, PRs, tags, and Releases before every create;
+  reuse exact matches and stop on conflicts.
+- Re-check the affected ref or exact PR head before every remote write.
 - Publish both the immutable version tag and the moving `v1` tag.
 - Verify `v1` and the version tag resolve to the same commit before finishing.
 - If pushing to `master` shows a branch-rule warning but the push succeeds, report that explicitly.
+- Never delete an immutable tag or GitHub Release automatically after a partial
+  failure. Report the last verified state and stop.

--- a/.agents/skills/direnv-action-release/references/release-guardrails.md
+++ b/.agents/skills/direnv-action-release/references/release-guardrails.md
@@ -21,7 +21,9 @@
   advances it to a strictly newer compatible immutable release, retain that
   target; hold on any other unexpected target.
 - Verify `v1` resolves to the intended release commit or a strictly newer
-  compatible immutable release before finishing.
+  compatible immutable release before finishing. Use fresh remote raw and
+  peeled refs, not a local `v1`; require one matching immutable version tag,
+  `master` ancestry, and a non-draft, non-prerelease GitHub Release.
 - If pushing to `master` shows a branch-rule warning but the push succeeds, report that explicitly.
 - Never delete an immutable tag or GitHub Release automatically after a partial
   failure. Report the last verified state and stop.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ This repository contains a JavaScript-based GitHub Action that installs `direnv`
 ├── package.json               # npm scripts and dependency definitions
 ├── eslint.config.js           # ESLint flat config
 ├── README.md                  # Usage, behavior, security, and development notes
-└── RELEASE_RUNBOOK.md         # Manual release process documentation
+└── RELEASE_RUNBOOK.md         # Manual and authorized automatic patch release process
 ```
 
 ## Core Behaviors & Patterns
@@ -47,4 +47,8 @@ This repository contains a JavaScript-based GitHub Action that installs `direnv`
 - For release work, prefer the repo skill at `.agents/skills/direnv-action-release/` and keep its references aligned with `RELEASE_RUNBOOK.md`.
 - Do not introduce unsupported platform/arch mappings without matching implementation and tests.
 - > TODO: Confirm branch protection, PR label policy, and required CI checks from repository settings.
-- You can push directly to `master` while in release process, but ensure all tests pass and the release runbook is followed for version bumps and changelog updates. For non-release changes, use feature branches and PRs with appropriate reviews.
+- An explicitly requested manual release may push directly to `master` after all
+  gates in the release runbook pass. An automatic patch-release handoff must use
+  a dedicated release-preparation branch and reviewed PR; it must never bypass
+  the branch rule with a direct `master` push. For other changes, use feature
+  branches and PRs with appropriate reviews.

--- a/RELEASE_RUNBOOK.md
+++ b/RELEASE_RUNBOOK.md
@@ -28,7 +28,9 @@ releases for versioned tags (for example, `v1.1.4`) and the moving major tag
    merged through a reviewed PR.
 3. A versioned tag such as `v1.1.4` is created from the verified release commit
    on `master` after validation.
-4. The moving major tag `v1` is force-updated to the same release commit after the versioned tag is pushed.
+4. The moving major tag `v1` is compare-and-swap updated to the same release
+   commit after the versioned tag is pushed. An automatic flow retains a
+   concurrently published strictly newer compatible immutable release.
 
 ## Legacy Cleanup
 
@@ -61,7 +63,10 @@ release write set. A successful dependency merge alone is not authorization.
    the latest immutable version tag.
 2. Require the complete release set to be patch-safe and to change a shipped
    runtime surface. Dev-only dependency, lint, test, CI, and docs-only sets are a
-   no-op. Hold on unclassified, medium/high-risk, breaking, or ambiguous sets.
+   no-op only when runtime artifacts remain unchanged. Classify source changes
+   before generated effects: hold when a dev-only tool regenerates `dist/**`,
+   when a bundler or releaser appears, or when the set is unclassified,
+   medium/high-risk, breaking, or ambiguous.
 3. Confirm the next patch version has no conflicting local or remote branch,
    release PR, immutable tag, or GitHub Release.
 4. Create `release/<next-version-tag>` from exact `origin/master` in a dedicated
@@ -102,7 +107,10 @@ release write set. A successful dependency merge alone is not authorization.
    before merge, re-check base, head, CI, release-set eligibility, and version
    collisions. Merge with a merge commit.
 8. Read back the release merge and require `origin/master` to equal that exact
-   merge commit. Continue with Phase 2 and Phase 3 from that commit.
+   merge commit. Continue with Phase 2 and Phase 3 from that commit. Before
+   moving `v1`, record and re-check its raw remote tag-object OID and peeled
+   target. Use a raw-OID compare-and-swap, retain a strictly newer compatible
+   release target, and hold on any other unexpected target.
 9. If any write partially succeeds, report the last verified state and stop.
    Never delete an immutable tag or GitHub Release automatically, undo the
    dependency merge, or repeat a successful write blindly.
@@ -216,19 +224,25 @@ Expected result:
 
 ## Phase 3: Move the `v1` major tag to the new release commit
 
-1. Update the local `v1` tag to the same release commit:
+1. Record the current raw remote `v1` tag-object OID, then update the local tag
+   to the same release commit:
 
    ```bash
+   expected_v1_object="$(git ls-remote origin refs/tags/v1 | awk '{print $1}')"
    git tag -fa v1 -m "Update v1 to <next-version-tag>"
    ```
 
-2. Force-push the updated `v1` tag:
+2. Compare-and-swap the updated `v1` tag:
 
    ```bash
-   git push origin refs/tags/v1 --force
+   git push \
+     --force-with-lease=refs/tags/v1:"${expected_v1_object}" \
+     origin refs/tags/v1
    ```
 
-3. Verify that both tags now point to the same commit:
+3. Verify that both tags now point to the same commit. In the automatic-flow
+   concurrency case, verify instead that `v1` points to a strictly newer
+   compatible immutable tag with a matching GitHub Release:
 
    ```bash
    git rev-list -n 1 <next-version-tag>
@@ -251,7 +265,7 @@ Expected result:
 - [ ] Generated `dist` and version files committed and pushed to `master`.
 - [ ] New version tag created from `master`.
 - [ ] Version tag pushed to remote.
-- [ ] `v1` tag force-updated to the same release commit.
+- [ ] `v1` retained on a strictly newer compatible release or compare-and-swap updated to the release commit.
 - [ ] `v1` tag push verified.
 
 ## Safety Notes
@@ -263,6 +277,9 @@ Expected result:
 - Do not update only one release-facing document when both `README.md` and `docs/index.html` pin the latest exact release tag.
 - Do not recreate the old `v1` branch after migration; `v1` should remain a tag only.
 - Force-updating `v1` changes what `@v1` resolves to, so confirm the target commit before pushing.
+- Never update `v1` with an unconditional force push. Compare the raw remote tag
+  object with `--force-with-lease`; retain a concurrently published strictly
+  newer compatible release and hold on every other unexpected target.
 - If the repository enables immutable release or tag policies, verify that moving `v1` is still allowed before starting the release.
 - Detect and reuse an exact in-progress release preparation; stop on conflicting
   branches, PRs, tags, or Releases instead of overwriting them.

--- a/RELEASE_RUNBOOK.md
+++ b/RELEASE_RUNBOOK.md
@@ -1,12 +1,16 @@
 # Release Runbook
 
-This runbook documents the release flow for versioned tags (for example, `v1.1.4`) and the moving major tag `v1`.
+This runbook documents manual releases and explicitly authorized automatic patch
+releases for versioned tags (for example, `v1.1.4`) and the moving major tag
+`v1`.
 
 ## Scope
 
 - Keep `master` as the source of truth for release-ready code and generated `dist` artifacts.
 - Publish a new versioned release tag from `master`.
 - Move the `v1` major tag to the newest compatible release commit.
+- Prepare unattended patch releases through a release-preparation PR; do not use
+  the manual direct-push path from a webhook workflow.
 
 ## Prerequisites
 
@@ -19,8 +23,11 @@ This runbook documents the release flow for versioned tags (for example, `v1.1.4
 ## Branch and Release Model
 
 1. `master` is the source of truth for the latest code and generated `dist` artifacts.
-2. Each release is prepared and validated on `master`.
-3. A versioned tag such as `v1.1.4` is created from `master` HEAD after validation.
+2. Manual releases may be prepared directly on `master` after explicit operator
+   authorization. Automatic patch releases are prepared on `release/v1.x.y` and
+   merged through a reviewed PR.
+3. A versioned tag such as `v1.1.4` is created from the verified release commit
+   on `master` after validation.
 4. The moving major tag `v1` is force-updated to the same release commit after the versioned tag is pushed.
 
 ## Legacy Cleanup
@@ -42,6 +49,66 @@ Run this section only once when migrating from the old `v1` branch-based process
 
 Expected result:
 - `v1` refers only to the moving major tag and is no longer ambiguous.
+
+---
+
+## Automatic Patch Release Path
+
+Use this path only when a trusted operator prompt explicitly authorizes the full
+release write set. A successful dependency merge alone is not authorization.
+
+1. Verify the dependency PR's exact-head merge and inventory every commit after
+   the latest immutable version tag.
+2. Require the complete release set to be patch-safe and to change a shipped
+   runtime surface. Dev-only dependency, lint, test, CI, and docs-only sets are a
+   no-op. Hold on unclassified, medium/high-risk, breaking, or ambiguous sets.
+3. Confirm the next patch version has no conflicting local or remote branch,
+   release PR, immutable tag, or GitHub Release.
+4. Create `release/<next-version-tag>` from exact `origin/master` in a dedicated
+   worktree. Apply the version and documentation updates described in Phase 1.
+5. Run both pre-change and post-change validation, including:
+
+   ```bash
+   nvm use
+   npm ci
+   npm run all
+   npm audit
+   npm audit --omit=dev
+   git diff --check
+   ```
+
+6. Commit `chore(release): prepare <next-version-tag>`, push only the release
+   branch, and open a non-draft PR with the repository-required body:
+
+   ```markdown
+   ## Summary
+
+   ## Background
+
+   ## Related issue(s)
+
+   ## Implementation details
+
+   ## Test coverage
+
+   ## Breaking changes
+
+   ## Notes
+
+   Created by Codex
+   ```
+
+7. Complete the standard reviewer procedure and exact-head GitHub CI. Immediately
+   before merge, re-check base, head, CI, release-set eligibility, and version
+   collisions. Merge with a merge commit.
+8. Read back the release merge and require `origin/master` to equal that exact
+   merge commit. Continue with Phase 2 and Phase 3 from that commit.
+9. If any write partially succeeds, report the last verified state and stop.
+   Never delete an immutable tag or GitHub Release automatically, undo the
+   dependency merge, or repeat a successful write blindly.
+
+The remainder of this runbook is the manual operator flow unless the automatic
+path explicitly references a phase.
 
 ---
 
@@ -109,7 +176,7 @@ Expected result:
    git commit -m "chore(release): prepare <next-version-tag>"
    ```
 
-10. Push the release preparation commit to `master`:
+10. In the manual operator flow, push the release preparation commit to `master`:
 
    ```bash
    git push origin master
@@ -178,6 +245,7 @@ Expected result:
 ## Operational Checklist
 
 - [ ] `master` updated with `npm run all` success.
+- [ ] Automatic patch flows classified the entire release set and used a reviewed release-preparation PR.
 - [ ] Release version determined and applied if needed.
 - [ ] `README.md` and `docs/index.html` updated for the latest pinned release version where applicable.
 - [ ] Generated `dist` and version files committed and pushed to `master`.
@@ -189,8 +257,12 @@ Expected result:
 ## Safety Notes
 
 - Do not create the release tag from an outdated local checkout.
+- Do not use the manual direct-`master` path from an automatic webhook handoff.
+- Do not infer automatic release authority from a merged dependency PR.
 - Do not skip the second `npm run all` after `npm version`; the generated artifacts and lockfile must match the release version.
 - Do not update only one release-facing document when both `README.md` and `docs/index.html` pin the latest exact release tag.
 - Do not recreate the old `v1` branch after migration; `v1` should remain a tag only.
 - Force-updating `v1` changes what `@v1` resolves to, so confirm the target commit before pushing.
 - If the repository enables immutable release or tag policies, verify that moving `v1` is still allowed before starting the release.
+- Detect and reuse an exact in-progress release preparation; stop on conflicting
+  branches, PRs, tags, or Releases instead of overwriting them.

--- a/RELEASE_RUNBOOK.md
+++ b/RELEASE_RUNBOOK.md
@@ -240,15 +240,38 @@ Expected result:
      origin refs/tags/v1
    ```
 
-3. Verify that both tags now point to the same commit. In the automatic-flow
-   concurrency case, verify instead that `v1` points to a strictly newer
-   compatible immutable tag with a matching GitHub Release:
+3. Read the remote refs again after the compare-and-swap. Do not use a possibly
+   stale local `v1` for final verification:
 
    ```bash
-   git rev-list -n 1 <next-version-tag>
-   git rev-list -n 1 v1
-   gh release view <next-version-tag>
+   git ls-remote origin \
+     refs/heads/master \
+     refs/tags/v1 \
+     'refs/tags/v1^{}' \
+     'refs/tags/v1.*' \
+     'refs/tags/v1.*^{}'
    ```
+
+4. Resolve the fresh peeled `v1` target to exactly one immutable `v1.x.y` tag.
+   Require the version to equal `<next-version-tag>` or, only for the automatic
+   concurrency path, to be a strictly newer compatible version. Fetch that
+   exact tag, prove its commit is an ancestor of remote `master`, and verify its
+   published Release:
+
+   ```bash
+   git fetch origin \
+     refs/heads/master:refs/remotes/origin/master \
+     refs/tags/<actual-version>:refs/tags/<actual-version>
+   git merge-base --is-ancestor \
+     "refs/tags/<actual-version>^{}" \
+     origin/master
+   gh release view <actual-version> \
+     --json tagName,isDraft,isPrerelease,url
+   ```
+
+   Require `isDraft=false` and `isPrerelease=false`. Hold if the peeled target
+   has zero or multiple immutable version tags, the SemVer or ancestry check
+   fails, or the matching GitHub Release cannot be proven.
 
 Expected result:
 - `v1` points to the newest compatible release commit.


### PR DESCRIPTION
## Summary

- add an explicitly authorized automatic patch-release workflow
- require a reviewed release-preparation PR instead of direct master pushes
- define release-set eligibility, no-op, hold, and partial-failure outcomes

## Background

The Dependabot maintainer workflow can safely merge narrowly classified low-risk updates. This change defines a separate release-owner handoff so an operator-authorized webhook may publish a patch release only when the complete unreleased commit set is patch-safe and changes a shipped runtime surface.

## Related issue(s)

None.

## Implementation details

- document write-authority boundaries for manual and automatic release paths
- add complete release-set and collision checks
- require a dedicated release branch, standard review, current exact-head CI, and merge commit
- require immutable tag and GitHub Release verification before moving v1
- preserve fail-closed handling for ambiguous, medium-risk, and high-risk changes

## Test coverage

- `python /home/filepang/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/direnv-action-release`
- `nvm use`
- `npm ci`
- `npm run all`
- `npm audit`
- `npm audit --omit=dev`
- `git diff --check`

## Breaking changes

None.

## Notes

This PR changes release policy documentation and the repository-owned release skill. It does not publish a release or run a webhook delivery.

Created by Codex