### PR TITLE
docs(release): allow medium-risk dependency automation

### DIFF
--- a/.agents/skills/direnv-action-release/SKILL.md
+++ b/.agents/skills/direnv-action-release/SKILL.md
@@ -43,7 +43,8 @@ operator path only.
 
 1. Confirm the verified dependency merge and classify every commit after the
    latest immutable version tag. Require every commit to be low or explicitly
-   authorized medium risk; high-risk signals take precedence.
+   authorized medium risk; high-risk signals take precedence. Require the
+   medium-risk evidence defined by the eligibility reference.
 2. Return `release_not_required` or `release_held` when the eligibility reference
    requires it.
 3. Detect an existing matching release branch, PR, tag, or GitHub Release before

--- a/.agents/skills/direnv-action-release/SKILL.md
+++ b/.agents/skills/direnv-action-release/SKILL.md
@@ -27,7 +27,8 @@ consistent while preserving the caller's write authority.
 - Never infer release authority from a merged dependency PR, changed `dist`, or
   skill invocation alone.
 - Stop automatic publication for minor, major, breaking, unclassified, or
-  medium/high-risk release sets.
+  high-risk release sets. Permit a fully classified low/medium-risk set only
+  when the trusted operator prompt explicitly authorizes medium-risk release.
 - Honor newer constraints such as `read only` or `do not release`.
 
 ## Select the Flow
@@ -41,16 +42,20 @@ operator path only.
 ### Authorized automatic patch release
 
 1. Confirm the verified dependency merge and classify every commit after the
-   latest immutable version tag.
+   latest immutable version tag. Require every commit to be low or explicitly
+   authorized medium risk; high-risk signals take precedence.
 2. Return `release_not_required` or `release_held` when the eligibility reference
    requires it.
 3. Detect an existing matching release branch, PR, tag, or GitHub Release before
    creating anything.
 4. Prepare the next patch version in a dedicated `release/v1.x.y` worktree.
 5. Update version files, `README.md`, and `docs/index.html`; run `nvm use`,
-   `npm ci`, `npm run all`, full and production audits, and diff checks.
-6. Commit and open a non-draft release-preparation PR using the repository PR
-   body contract. Run the standard reviewer procedure and wait for current CI.
+   `npm ci`, mandatory `npm run prepare`, `npm run all`, full and production
+   audits, and diff checks.
+6. Commit the release preparation, run `npm run prepare` again, and require the
+   complete working tree to remain clean before pushing. Open a non-draft PR
+   using the repository PR body contract, run the standard reviewer procedure,
+   and wait for current CI.
 7. Re-check the exact release PR head before merge, use a merge commit, and
    verify the merge read-back.
 8. Publish the annotated immutable tag and GitHub Release from the exact release

--- a/.agents/skills/direnv-action-release/references/release-eligibility.md
+++ b/.agents/skills/direnv-action-release/references/release-eligibility.md
@@ -3,10 +3,29 @@
 Use this contract only for a trusted automatic handoff after a verified
 Dependabot merge. Do not use it to broaden the Dependabot merge-risk policy.
 
+## Require a verified risk handoff
+
+Consume the classification produced by `dependabot-pr-maintainer`; do not infer
+an easier class from release impact:
+
+- medium risk includes a direct dev dependency with extra attributable
+  transitive churn, a non-high-risk security fix with notable subtree changes,
+  a fully attributable grouped dev update, or a dev bundler/build-tool update
+  with expected reproducible artifacts;
+- high risk includes a major update, runtime dependency, install script,
+  maintainer/releaser change, auth/proxy/network/request-path library,
+  unexpected generated artifact, breaking change, or ambiguous surface; and
+- any high-risk signal takes precedence over a medium-risk shape.
+
+For a medium-risk handoff, require upstream metadata and release-note review,
+complete diff and artifact attribution, exact merged-head clean-build evidence,
+no unresolved reviewer findings, and current exact-head CI. Hold when this
+evidence is incomplete or stale.
+
 ## Require all conditions
 
 - The original PR was merged inside its authorized unattended low/medium-risk
-  boundary.
+  boundary and carries the required classification evidence.
 - Merge read-back proves the verified PR head is a parent of the merge commit.
 - The latest immutable version tag and its peeled commit are unambiguous.
 - Every commit after that tag through the verified merge commit maps to a reviewed

--- a/.agents/skills/direnv-action-release/references/release-eligibility.md
+++ b/.agents/skills/direnv-action-release/references/release-eligibility.md
@@ -5,28 +5,32 @@ Dependabot merge. Do not use it to broaden the Dependabot merge-risk policy.
 
 ## Require all conditions
 
-- The original PR was merged inside its authorized unattended risk boundary.
+- The original PR was merged inside its authorized unattended low/medium-risk
+  boundary.
 - Merge read-back proves the verified PR head is a parent of the merge commit.
 - The latest immutable version tag and its peeled commit are unambiguous.
 - Every commit after that tag through the verified merge commit maps to a reviewed
   PR or an already verified release-safe commit.
-- The complete release set is patch SemVer: no breaking change, new input/output,
-  behavior contract expansion, or required migration.
+- The complete release set contains only classified low or explicitly authorized
+  medium-risk changes and is patch SemVer: no breaking change, new input/output,
+  behavior contract expansion, or required migration. High-risk signals always
+  take precedence.
 - The set changes a shipped runtime surface because of a source, `action.yml`,
-  production-dependency, or runtime-security change. Generated `dist/**` is
-  evidence of that source change, not an independent reason to release.
+  production-dependency, runtime-security, or authorized medium-risk dev bundler
+  change. Generated `dist/**` must be expected, attributable, and reproducible;
+  it is not an independent reason to release.
 - No install script, maintainer/releaser warning, auth/proxy/network/request-path
   change, unexpected generated artifact, or failing gate exists.
 
 Classify the cause before generated effects. Return `release_not_required` when
 changes are limited to dev-only lockfile, lint, test, CI, or documentation
-updates and committed runtime artifacts are unchanged. Return `release_held`
-when a dev-only tool change regenerates `dist/**`, or when a bundler or releaser
-change appears anywhere in the release set; do not treat generated output as a
-way around the original risk boundary.
+updates and committed runtime artifacts are unchanged. An authorized medium-risk
+dev bundler may qualify when its generated `dist/**` is expected and reproducible.
+Return `release_held` for unexpected or non-reproducible generated output, or
+when a releaser change appears.
 
 Return `release_held` when any commit is unclassified, the release set includes a
-medium/high-risk change, patch SemVer is uncertain, a matching release artifact
+high-risk change, patch SemVer is uncertain, a matching release artifact
 conflicts, or a required gate cannot be proven current.
 
 ## Version and collision checks
@@ -49,8 +53,9 @@ conflicts, or a required gate cannot be proven current.
 - release-set commit and PR inventory;
 - exact source `origin/master` SHA;
 - Node and npm versions from `.nvmrc`;
-- clean `npm ci`, `npm run all`, `npm audit`, `npm audit --omit=dev`, and
-  `git diff --check`;
+- clean `npm ci`, mandatory post-version `npm run prepare`, `npm run all`,
+  `npm audit`, `npm audit --omit=dev`, and `git diff --check`;
+- a post-commit `npm run prepare` that leaves the complete working tree clean;
 - expected file set for the release preparation;
 - reviewer findings and exact-head GitHub CI;
 - release PR merge commit and parent relationship;

--- a/.agents/skills/direnv-action-release/references/release-flow.md
+++ b/.agents/skills/direnv-action-release/references/release-flow.md
@@ -18,11 +18,15 @@ Use this checklist after reading `RELEASE_RUNBOOK.md`.
    - `git log <last-release-tag>..HEAD --oneline`
 4. Apply the next version:
    - `npm version <next-version> --no-git-tag-version`
-5. Update docs that pin the release tag, including `README.md` and `docs/index.html`, then rerun:
+5. Regenerate the distributable, update docs that pin the release tag, including
+   `README.md` and `docs/index.html`, then rerun:
+   - `npm run prepare`
    - `npm run all`
 6. Commit and publish:
    - `git add package.json package-lock.json README.md docs/index.html dist`
    - `git commit -m "chore(release): prepare <next-version-tag>"`
+   - `npm run prepare`
+   - require `git status --porcelain` to be empty
    - `git push origin master`
 7. Tag and release:
    - `git tag -a <next-version-tag> -m "Release <next-version-tag>"`
@@ -53,6 +57,7 @@ Use this checklist after reading `RELEASE_RUNBOOK.md`.
    - `npm run all`
    - `npm version <next-version> --no-git-tag-version`
    - update `README.md` and `docs/index.html`
+   - `npm run prepare`
    - `npm run all`
    - `npm audit`
    - `npm audit --omit=dev`
@@ -61,6 +66,7 @@ Use this checklist after reading `RELEASE_RUNBOOK.md`.
    - stage only `package.json`, `package-lock.json`, `README.md`,
      `docs/index.html`, and expected regenerated `dist` files;
    - commit `chore(release): prepare <next-version-tag>`;
+   - run `npm run prepare` again and require `git status --porcelain` to be empty;
    - re-check the source branch ref, then push the release branch.
 5. Open a non-draft PR with the required repository body sections and
    `Created by Codex`; apply the appropriate release or maintenance label.

--- a/.agents/skills/direnv-action-release/references/release-flow.md
+++ b/.agents/skills/direnv-action-release/references/release-flow.md
@@ -12,6 +12,7 @@ Use this checklist after reading `RELEASE_RUNBOOK.md`.
    - `nvm use`
    - `npm ci`
    - `npm run all`
+   - require `git status --porcelain` to be empty
 3. Inspect version state:
    - `git tag --sort=-version:refname | head -n 5`
    - `grep '"version":' package.json`
@@ -22,6 +23,8 @@ Use this checklist after reading `RELEASE_RUNBOOK.md`.
    `README.md` and `docs/index.html`, then rerun:
    - `npm run prepare`
    - `npm run all`
+   - `npm audit`
+   - `npm audit --omit=dev`
 6. Commit and publish:
    - `git add package.json package-lock.json README.md docs/index.html dist`
    - `git commit -m "chore(release): prepare <next-version-tag>"`
@@ -55,6 +58,7 @@ Use this checklist after reading `RELEASE_RUNBOOK.md`.
 3. Prepare from exact `origin/master` in a dedicated worktree:
    - `npm ci`
    - `npm run all`
+   - require `git status --porcelain` to be empty before changing the version
    - `npm version <next-version> --no-git-tag-version`
    - update `README.md` and `docs/index.html`
    - `npm run prepare`

--- a/.agents/skills/direnv-action-release/references/release-guardrails.md
+++ b/.agents/skills/direnv-action-release/references/release-guardrails.md
@@ -5,12 +5,15 @@
   handoff must use a dedicated release-preparation PR.
 - Use the Node version from `.nvmrc`.
 - Classify every commit since the latest immutable version tag before automatic
-  patch preparation. Hold on unclassified or non-patch-safe commits.
-- Classify the source change before generated `dist/**`. A dev-only tool must not
-  become release-eligible merely because it regenerates committed artifacts;
-  bundler and releaser changes always hold the automatic path.
-- Always run `npm run all` after the version bump.
-- Do not hand-edit `dist/`; regenerate it through `npm run prepare` as part of `npm run all`.
+  patch preparation. Require low or explicitly authorized medium risk and hold
+  on high-risk, unclassified, or non-patch-safe commits.
+- Classify the source change before generated `dist/**`. An explicitly authorized
+  medium-risk dev bundler may qualify only when its artifacts are expected,
+  attributable, and reproducible. Releaser changes always hold.
+- Always run `npm run prepare` explicitly after the version bump, then run
+  `npm run all`.
+- Do not hand-edit `dist/`. After the release-preparation commit, regenerate it
+  again with `npm run prepare` and require the complete working tree to be clean.
 - Update both `README.md` and `docs/index.html` when they pin the latest exact release tag.
 - Use a Conventional Commit message for the release-preparation commit.
 - Detect existing release branches, PRs, tags, and Releases before every create;

--- a/.agents/skills/direnv-action-release/references/release-guardrails.md
+++ b/.agents/skills/direnv-action-release/references/release-guardrails.md
@@ -7,11 +7,13 @@
 - Classify every commit since the latest immutable version tag before automatic
   patch preparation. Require low or explicitly authorized medium risk and hold
   on high-risk, unclassified, or non-patch-safe commits.
+- Require the exact merged dependency head to remain clean after its baseline
+  install and full build before applying a release version change.
 - Classify the source change before generated `dist/**`. An explicitly authorized
   medium-risk dev bundler may qualify only when its artifacts are expected,
   attributable, and reproducible. Releaser changes always hold.
 - Always run `npm run prepare` explicitly after the version bump, then run
-  `npm run all`.
+  `npm run all` and both full and production audits.
 - Do not hand-edit `dist/`. After the release-preparation commit, regenerate it
   again with `npm run prepare` and require the complete working tree to be clean.
 - Update both `README.md` and `docs/index.html` when they pin the latest exact release tag.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,5 +50,7 @@ This repository contains a JavaScript-based GitHub Action that installs `direnv`
 - An explicitly requested manual release may push directly to `master` after all
   gates in the release runbook pass. An automatic patch-release handoff must use
   a dedicated release-preparation branch and reviewed PR; it must never bypass
-  the branch rule with a direct `master` push. For other changes, use feature
-  branches and PRs with appropriate reviews.
+  the branch rule with a direct `master` push. Every release must explicitly
+  regenerate `dist/` after the version change and prove a post-commit rebuild
+  leaves the working tree clean. For other changes, use feature branches and PRs
+  with appropriate reviews.

--- a/RELEASE_RUNBOOK.md
+++ b/RELEASE_RUNBOOK.md
@@ -61,6 +61,22 @@ Expected result:
 Use this path only when a trusted operator prompt explicitly authorizes the full
 release write set. A successful dependency merge alone is not authorization.
 
+Risk classification is part of the required handoff:
+
+- medium risk includes a direct dev dependency with extra attributable
+  transitive churn, a non-high-risk security fix with notable subtree changes,
+  a fully attributable grouped dev update, or a dev bundler/build-tool update
+  with expected reproducible artifacts;
+- high risk includes a major update, runtime dependency, install script,
+  maintainer/releaser change, auth/proxy/network/request-path library,
+  unexpected generated artifact, breaking change, or ambiguous surface; and
+- any high-risk signal takes precedence over a medium-risk shape.
+
+An unattended medium-risk merge must provide upstream metadata and release-note
+review, complete diff and artifact attribution, exact merged-head clean-build
+evidence, no unresolved reviewer findings, and current exact-head CI. The
+release workflow consumes this evidence and holds when it is incomplete or stale.
+
 1. Verify the dependency PR's exact-head merge and inventory every commit after
    the latest immutable version tag.
 2. Require every commit in the complete release set to be classified low or
@@ -82,6 +98,7 @@ release write set. A successful dependency merge alone is not authorization.
    nvm use
    npm ci
    npm run all
+   test -z "$(git status --porcelain)"
    npm version <next-version> --no-git-tag-version
    npm run prepare
    npm run all
@@ -145,6 +162,7 @@ path explicitly references a phase.
    nvm use
    npm ci
    npm run all
+   test -z "$(git status --porcelain)"
    ```
 
 3. Check the latest release tags:
@@ -180,6 +198,8 @@ path explicitly references a phase.
    ```bash
    npm run prepare
    npm run all
+   npm audit
+   npm audit --omit=dev
    ```
 
 8. Update documentation that references the latest pinned release version.
@@ -301,10 +321,12 @@ Expected result:
 ## Operational Checklist
 
 - [ ] `master` updated with `npm run all` success.
+- [ ] Baseline install and build left the exact source tree clean before the version change.
 - [ ] Automatic patch flows classified the entire release set and used a reviewed release-preparation PR.
 - [ ] Release version determined and applied if needed.
 - [ ] `dist/**` explicitly regenerated after the release version change.
 - [ ] Post-commit `npm run prepare` left the complete working tree clean.
+- [ ] Full and production npm audits passed.
 - [ ] `README.md` and `docs/index.html` updated for the latest pinned release version where applicable.
 - [ ] Generated `dist` and version files committed and pushed to `master`.
 - [ ] New version tag created from `master`.

--- a/RELEASE_RUNBOOK.md
+++ b/RELEASE_RUNBOOK.md
@@ -7,6 +7,8 @@ releases for versioned tags (for example, `v1.1.4`) and the moving major tag
 ## Scope
 
 - Keep `master` as the source of truth for release-ready code and generated `dist` artifacts.
+- Regenerate `dist/**` after every release version change and prove the committed
+  bundle is reproducible before publishing.
 - Publish a new versioned release tag from `master`.
 - Move the `v1` major tag to the newest compatible release commit.
 - Prepare unattended patch releases through a release-preparation PR; do not use
@@ -61,29 +63,36 @@ release write set. A successful dependency merge alone is not authorization.
 
 1. Verify the dependency PR's exact-head merge and inventory every commit after
    the latest immutable version tag.
-2. Require the complete release set to be patch-safe and to change a shipped
-   runtime surface. Dev-only dependency, lint, test, CI, and docs-only sets are a
-   no-op only when runtime artifacts remain unchanged. Classify source changes
-   before generated effects: hold when a dev-only tool regenerates `dist/**`,
-   when a bundler or releaser appears, or when the set is unclassified,
-   medium/high-risk, breaking, or ambiguous.
+2. Require every commit in the complete release set to be classified low or
+   explicitly authorized medium risk and require the set to be patch-safe.
+   High-risk signals take precedence. Dev-only dependency, lint, test, CI, and
+   docs-only sets are a no-op when runtime artifacts remain unchanged. An
+   authorized medium-risk dev bundler may qualify when its `dist/**` changes are
+   expected, attributable, and reproducible. Hold on releaser, high-risk,
+   unclassified, breaking, ambiguous, unexpected, or non-reproducible changes.
 3. Confirm the next patch version has no conflicting local or remote branch,
    release PR, immutable tag, or GitHub Release.
 4. Create `release/<next-version-tag>` from exact `origin/master` in a dedicated
-   worktree. Apply the version and documentation updates described in Phase 1.
-5. Run both pre-change and post-change validation, including:
+   worktree.
+5. Run the baseline gate, apply the version and documentation updates described
+   in Phase 1, explicitly regenerate `dist/**`, and run the post-change gates in
+   this order:
 
    ```bash
    nvm use
    npm ci
+   npm run all
+   npm version <next-version> --no-git-tag-version
+   npm run prepare
    npm run all
    npm audit
    npm audit --omit=dev
    git diff --check
    ```
 
-6. Commit `chore(release): prepare <next-version-tag>`, push only the release
-   branch, and open a non-draft PR with the repository-required body:
+6. Commit `chore(release): prepare <next-version-tag>`, run `npm run prepare`
+   again, and require `git status --porcelain` to be empty. Only then push the
+   release branch and open a non-draft PR with the repository-required body:
 
    ```markdown
    ## Summary
@@ -165,9 +174,11 @@ path explicitly references a phase.
    Note:
    - `npm version` usually updates both `package.json` and `package-lock.json`.
 
-7. Rebuild and rerun the full validation gate after the version update:
+7. Explicitly regenerate `dist/**`, then rerun the full validation gate after
+   the version update:
 
    ```bash
+   npm run prepare
    npm run all
    ```
 
@@ -184,7 +195,15 @@ path explicitly references a phase.
    git commit -m "chore(release): prepare <next-version-tag>"
    ```
 
-10. In the manual operator flow, push the release preparation commit to `master`:
+10. Regenerate `dist/**` from the committed release state and require no
+    uncommitted change:
+
+    ```bash
+    npm run prepare
+    test -z "$(git status --porcelain)"
+    ```
+
+11. In the manual operator flow, push the release preparation commit to `master`:
 
    ```bash
    git push origin master
@@ -284,6 +303,8 @@ Expected result:
 - [ ] `master` updated with `npm run all` success.
 - [ ] Automatic patch flows classified the entire release set and used a reviewed release-preparation PR.
 - [ ] Release version determined and applied if needed.
+- [ ] `dist/**` explicitly regenerated after the release version change.
+- [ ] Post-commit `npm run prepare` left the complete working tree clean.
 - [ ] `README.md` and `docs/index.html` updated for the latest pinned release version where applicable.
 - [ ] Generated `dist` and version files committed and pushed to `master`.
 - [ ] New version tag created from `master`.
@@ -296,6 +317,8 @@ Expected result:
 - Do not create the release tag from an outdated local checkout.
 - Do not use the manual direct-`master` path from an automatic webhook handoff.
 - Do not infer automatic release authority from a merged dependency PR.
+- Do not publish any release without explicitly regenerating `dist/**` after the
+  version change and proving the post-commit rebuild is clean.
 - Do not skip the second `npm run all` after `npm version`; the generated artifacts and lockfile must match the release version.
 - Do not update only one release-facing document when both `README.md` and `docs/index.html` pin the latest exact release tag.
 - Do not recreate the old `v1` branch after migration; `v1` should remain a tag only.


### PR DESCRIPTION
## Summary

- allow explicitly authorized medium-risk dependency sets in automatic patch releases
- keep high-risk signals fail-closed and higher precedence
- require `dist/**` regeneration and a clean post-commit rebuild for every release

## Background

Dependency maintenance and releases are delegated to the automated maintainer workflow. The trusted policy now permits the complete medium-risk class while preserving human review for high-risk, breaking, and ambiguous changes.

## Related issue(s)

None.

## Implementation details

- accept fully classified low/medium-risk release sets under explicit operator authority
- allow attributable and reproducible dev-bundler artifact changes
- retain holds for runtime, install-script, releaser, auth/network-path, major, and ambiguous changes
- explicitly run `npm run prepare` after the version change
- rerun `npm run prepare` after the release-preparation commit and require a clean tree

## Test coverage

- `python /home/filepang/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/direnv-action-release`
- `nvm use`
- `npm ci`
- `npm run all`
- `npm audit`
- `npm audit --omit=dev`
- post-commit `npm run prepare` with a clean working tree
- `git diff --check`

## Breaking changes

None.

## Notes

This PR changes release policy documentation and the repository-owned release skill. It does not process a Dependabot PR, publish a release, or execute a webhook delivery.

Created by Codex