### PR TITLE
Simplify the CodeQL advanced scanning workflow

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,3 @@
+paths-ignore:
+  - dist/**
+  - "**/*test*.js"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,96 +1,35 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
-name: "CodeQL"
+name: CodeQL
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [master]
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ "master" ]
+    branches: [master]
   schedule:
-    - cron: '26 7 * * 6'
+    - cron: "26 7 * * 6"
+
+permissions:
+  contents: read
+  security-events: write
 
 jobs:
   analyze:
-    name: Analyze
+    name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+        language: [javascript-typescript, actions]
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v7
-
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4.37.8
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-
-        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
-
-
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v4.37.8
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-    #   If the Autobuild fails above, remove it and uncomment the following three lines.
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
-    # - run: |
-    #   echo "Run, Build Application using script"
-    #   ./location_of_script_within_repo/buildscript.sh
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4.37.8
-      with:
-        upload: False
-        output: sarif-results
-
-    - name: filter-sarif
-      uses: advanced-security/filter-sarif@v1
-      with:
-        patterns: |
-          -dist/**
-          -**/*test*.js
-        input: sarif-results/javascript.sarif
-        output: sarif-results/javascript.sarif
-
-    - name: Upload SARIF
-      uses: github/codeql-action/upload-sarif@v4.37.8
-      with:
-        sarif_file: sarif-results/javascript.sarif
-
-    - name: Upload loc as a Build Artifact
-      uses: actions/upload-artifact@v7
-      with:
-        name: sarif-results
-        path: sarif-results
-        retention-days: 1
+      - name: Checkout repository
+        uses: actions/checkout@v7
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          config-file: ./.github/codeql/codeql-config.yml
+          languages: ${{ matrix.language }}
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

Simplify the CodeQL advanced scanning workflow and use native CodeQL path exclusions.

## Background

The existing workflow used an unnecessary autobuild step for JavaScript, disabled the analysis action's automatic upload, filtered the generated SARIF with a third-party action, uploaded it again, and retained the SARIF as a short-lived artifact.

## Related issue(s)

None.

## Implementation details

- Analyze JavaScript/TypeScript and GitHub Actions workflows.
- Keep scans on pushes and pull requests targeting `master`, plus the existing weekly schedule.
- Use the CodeQL v4 major tag and the analysis action's built-in upload behavior.
- Remove the autobuild, external SARIF filtering, explicit SARIF upload, and artifact upload steps.
- Exclude generated `dist/**` files and JavaScript test files through a native CodeQL configuration file.
- Keep workflow permissions limited to repository contents reads and security event writes.

## Test coverage

- `npm run all`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/codeql.yml`
- `git diff --check`

## Breaking changes

None.

## Notes

The first hosted CodeQL analysis using the simplified workflow will run on this pull request.

Created by Codex
