### PR TITLE
Restore the default Dependabot update cadence

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,4 +15,4 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: "weekly"
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,14 +10,6 @@ updates:
     groups:
       dev-dependencies:
         dependency-type: "development"
-    cooldown:
-      default-days: 7
-      include:
-        - "@eslint/js"
-        - "@vercel/ncc"
-        - "eslint"
-        - "globals"
-        - "vitest"
 
   # Enable version updates for actions
   - package-ecosystem: github-actions


### PR DESCRIPTION
## Summary

Restore the normal Dependabot cadence for npm updates and check GitHub Actions updates daily.

## Background

The npm cooldown reduced Dependabot PR frequency while updates required more manual handling. The repository now processes eligible Dependabot PRs through its webhook automation, so the extra npm delay and weekly GitHub Actions interval are no longer needed.

## Related issue(s)

None.

## Implementation details

- Keep the npm schedule at `daily`.
- Remove the package-specific seven-day npm `cooldown` configuration, returning it to GitHub default behavior.
- Keep development dependencies grouped.
- Change the GitHub Actions schedule from `weekly` to `daily`.

## Test coverage

- Parsed `.github/dependabot.yml` and asserted both schedules are daily with no npm cooldown override.
- `npm run all` (lint, distributable build, 48 unit tests)
- `git diff --check`

## Breaking changes

None.

## Notes

This intentionally increases the arrival rate of eligible npm and GitHub Actions Dependabot PRs.

Created by Codex